### PR TITLE
ci: fix RUSTFLAGS on github workflow

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -6,6 +6,9 @@ on:
 
 name: CI
 
+env:
+  RUSTFLAGS: "--cfg=web_sys_unstable_apis"
+
 jobs:
 
   build:


### PR DESCRIPTION
Fix github action CI pipeline enabling unstable flag for `web_sys` in order to use `SerialPort` , following https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.SerialPort.html .

A similar approach is defined inside gitlab CI pipeline, defining the flag in [context/env.sh](https://github.com/lvaccaro/lwk/commit/8886cb9746c17026ce7543b4ec2e8517ccb28a85#diff-a468edfabd1f70d073b26439c7a777d65e48fb461e9cdf323ad825f487afcde6)