### PR TITLE
ci: pre-install toolchain components

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
      - uses: actions/checkout@v4
      - uses: dtolnay/rust-toolchain@1.75.0
+       with:
+         components: "clippy,rust-src,rustfmt" # required by maturin build
      - uses: actions/setup-python@v5
        with:
          python-version: "3.12"
@@ -29,6 +31,8 @@ jobs:
     steps:
      - uses: actions/checkout@v4
      - uses: dtolnay/rust-toolchain@1.75.0
+       with:
+         components: "clippy,rust-src,rustfmt" # required by maturin build
      - uses: actions/setup-python@v5
        with:
          python-version: "3.12"


### PR DESCRIPTION
the components are later required by maturin, and pre-installing seems to fixes an error on windows

```
Run maturin build --release -m lwk_bindings/Cargo.toml -b uniffi
info: syncing channel updates for '1.75.0-x86_64-pc-windows-msvc'
info: latest update on 2023-12-28, rust version 1.75.0 (82e1608df 2023-12-21)
info: component 'cargo' for target 'x86_64-pc-windows-msvc' is up to date
info: component 'rust-std' for target 'x86_64-pc-windows-msvc' is up to date
info: component 'rustc' for target 'x86_64-pc-windows-msvc' is up to date
info: downloading component 'clippy'
info: downloading component 'rust-src'
info: downloading component 'rustfmt'
info: installing component 'clippy'
info: rolling back changes
error: failed to install component: 'clippy-preview-x86_64-pc-windows-msvc', detected conflict: 'bin/cargo-clippy.exe'
💥 maturin failed
  Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
  Caused by: `cargo metadata` exited with an error: 
Error: Process completed with exit code 1.
```