### PR TITLE
Add public to get_txout

### DIFF
--- a/lwk_wollet/src/pset_create.rs
+++ b/lwk_wollet/src/pset_create.rs
@@ -40,7 +40,7 @@ impl Wollet {
             .clone())
     }
 
-    fn get_txout(&self, outpoint: &OutPoint) -> Result<TxOut, Error> {
+    pub fn get_txout(&self, outpoint: &OutPoint) -> Result<TxOut, Error> {
         Ok(self
             .get_tx(&outpoint.txid)?
             .output


### PR DESCRIPTION
This is necessary for signing a pset coming from sideswap integration.

We need to add extra details to their pset:

- Add in_utxo_rangeproof
- Add witness_utxo

It is currently not possible to add these without this function being public.