### PR TITLE
Make `lwk_wollet::clients::History` fields public

### DIFF
--- a/lwk_wollet/src/clients/mod.rs
+++ b/lwk_wollet/src/clients/mod.rs
@@ -247,15 +247,15 @@ pub trait BlockchainBackend {
 }
 
 pub struct History {
-    txid: Txid,
+    pub txid: Txid,
 
     /// Confirmation height of txid
     ///
     /// -1 means unconfirmed with unconfirmed parents
     ///  0 means unconfirmed with confirmed parents
-    height: i32,
+    pub height: i32,
 
-    block_hash: Option<BlockHash>,
+    pub block_hash: Option<BlockHash>,
 }
 
 pub fn try_unblind(output: TxOut, descriptor: &WolletDescriptor) -> Result<TxOutSecrets, Error> {


### PR DESCRIPTION
Make `History` fields public, so callers can access them when working with the results of `ElectrumClient::get_scripts_history`.