### PR TITLE
rpc_model: correct fee rate unit to sat/kvB

### DIFF
--- a/lwk_rpc_model/src/request.rs
+++ b/lwk_rpc_model/src/request.rs
@@ -168,7 +168,7 @@ pub struct WalletDrain {
     /// Recipient addresse
     pub address: String,
 
-    /// Optional fee rate in sat/vb
+    /// Optional fee rate in sat/kvB
     pub fee_rate: Option<f32>,
 }
 

--- a/lwk_rpc_model/src/request.rs
+++ b/lwk_rpc_model/src/request.rs
@@ -138,7 +138,7 @@ pub struct WalletSendMany {
     /// Recipient addressees
     pub addressees: Vec<UnvalidatedAddressee>,
 
-    /// Optional fee rate in sat/vb
+    /// Optional fee rate in sat/kvB
     pub fee_rate: Option<f32>,
 }
 

--- a/lwk_wollet/src/tx_builder.rs
+++ b/lwk_wollet/src/tx_builder.rs
@@ -142,7 +142,8 @@ impl TxBuilder {
         self.add_unvalidated_recipient(&rec)
     }
 
-    /// Set custom fee rate
+    /// Fee rate in sats/kvb
+    /// Multiply sats/vb value by 1000 i.e. 1.0 sat/byte = 1000.0 sat/kvb
     pub fn fee_rate(mut self, fee_rate: Option<f32>) -> Self {
         if let Some(fee_rate) = fee_rate {
             self.fee_rate = fee_rate


### PR DESCRIPTION
correct fee rate unit from sat/vb to sat/kvB in WalletSendMany struct.