### PR TITLE
Use lwk_wasm from npm to fix confusion and improve ease of use

### DIFF
--- a/lwk_wasm/www/package-lock.json
+++ b/lwk_wasm/www/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "lwk_wasm": "file:../pkg"
+        "lwk_wasm": "^0.7.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^11.0.0",
@@ -14,11 +14,6 @@
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1"
       }
-    },
-    "../pkg": {
-      "name": "lwk_wasm",
-      "version": "0.4.1",
-      "license": "MIT OR BSD-2-Clause"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -2114,8 +2109,9 @@
       }
     },
     "node_modules/lwk_wasm": {
-      "resolved": "../pkg",
-      "link": true
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/lwk_wasm/-/lwk_wasm-0.7.0.tgz",
+      "integrity": "sha512-vnhjAuZX9eUDm8cwTKqHKU91MnkYt2/0yipJ2fHL1JlIgLrWkeMQy9bNRcsKNm/AbmhOGBfO71q5EnW+ipOsAQ=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",

--- a/lwk_wasm/www/package.json
+++ b/lwk_wasm/www/package.json
@@ -4,7 +4,7 @@
     "build": "webpack --config webpack.config.js"
   },
   "dependencies": {
-    "lwk_wasm": "file:../pkg"
+    "lwk_wasm": "^0.7.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^11.0.0",


### PR DESCRIPTION
When I was trying to run the example app in `lwk_wasm/www`, the README.md guide only told me to `npm install` and `npm run start` and it should work.

But it didn't though, because the dependency `lwk_wasm` couldn't be found by webpack.

I headed to investigate the cause and I found that it was loading it as a relative path, to `../pkg...` , this however assumes that developer has built the package themselves prior to this, but it isn't mentioned anywhere here they should do that. So it crashes and they have no idea why.

#### So I propose...

...the `package.json` config file should take `lwk_wasm` dependency from NPM registry, so that it is easy to just `npm install` everything, is up-to-date and person can just then `npm run start` and it will work, just like that.