### PR TITLE
Add swift bindings

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ swift: ios ios-sim
     mkdir -p ./target/swift/include
     mv target/swift/LiquidWalletKitFFI.h target/swift/include
     mv target/swift/LiquidWalletKitFFI.modulemap  target/swift/include/module.modulemap
-    xcodebuild -create-xcframework -library target/lipo-ios-sim/release/liblwk.a -headers target/swift/include -library target/aarch64-apple-ios/release/liblwk.a -headers target/swift/include -output lwk.xcframework
+    xcodebuild -create-xcframework -library target/lipo-ios-sim/release/liblwk.a -headers target/swift/include -library target/aarch64-apple-ios/release/liblwk.a -headers target/swift/include -output target/lwk.xcframework
 
 ios: aarch64-apple-ios
 

--- a/justfile
+++ b/justfile
@@ -36,3 +36,25 @@ i686-linux-android:
 
 x86_64-linux-android:
 	cargo ndk -t x86_64-linux-android -o target/release/kotlin/jniLibs build -p lwk_bindings
+
+swift: ios ios-sim
+    cargo run --features bindings -- generate --library ./target/aarch64-apple-ios/release/liblwk.a --language swift --out-dir ./target/swift
+    mkdir -p ./target/swift/include
+    mv target/swift/LiquidWalletKitFFI.h target/swift/include
+    mv target/swift/LiquidWalletKitFFI.modulemap  target/swift/include/module.modulemap
+    xcodebuild -create-xcframework -library target/lipo-ios-sim/release/liblwk.a -headers target/swift/include -library target/aarch64-apple-ios/release/liblwk.a -headers target/swift/include -output lwk.xcframework
+
+ios: aarch64-apple-ios
+
+ios-sim: x86_64-apple-ios aarch64-apple-ios-sim
+    mkdir -p target/lipo-ios-sim/release
+    lipo target/aarch64-apple-ios-sim/release/liblwk.a target/x86_64-apple-ios/release/liblwk.a -create -output target/lipo-ios-sim/release/liblwk.a
+
+x86_64-apple-ios:
+    cargo build --features bindings --release --target x86_64-apple-ios
+
+aarch64-apple-ios:
+    cargo build --features bindings --release --target aarch64-apple-ios
+
+aarch64-apple-ios-sim:
+    cargo build --features bindings --release --target aarch64-apple-ios-sim

--- a/lwk_bindings/Cargo.toml
+++ b/lwk_bindings/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1"
 uniffi = { version = "0.26.1", features = ["build"] }
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["staticlib", "cdylib", "rlib"]
 name = "lwk"
 
 [features]

--- a/lwk_bindings/uniffi.toml
+++ b/lwk_bindings/uniffi.toml
@@ -4,3 +4,6 @@ package_name = "lwk"
 [bindings.python]
 cdylib_name = "lwk"
 
+[bindings.swift]
+module_name = "LiquidWalletKit"
+cdylib_name = "lwk"


### PR DESCRIPTION
Build swift bindings for iphone and iphone simulator with:

```
just swift
```

The output framework is `target/lwk.xcframework`.

Import the xcframework in the xcode project and import into swift code

```
import LiquidWalletKitFFI
...
```
