### PR TITLE
ci: trigger android github action on tag for publishing

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'bindings_*'
   pull_request: {}
 
 name: Build & Publish framework for Kotlin library
@@ -44,14 +46,40 @@ jobs:
         run: |
           ./gradlew build --console=plain
 
+      - name: Temporarily save artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lwk-artifact
+          path: lwk_bindings/android_bindings
+          retention-days: 1
+
   publish:
     runs-on: ubuntu-20.04
     needs: build
     if: startsWith(github.ref, 'refs/tags/bindings_')
     steps:
+
+      - name: Retrieve saved artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: lwk-artifact
+
+      - name: "Set up JDK"
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set RELEASE_REF
+        run: echo "RELEASE_REF=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Set RELEASE_VERSION
+        run: echo "RELEASE_VERSION=$(echo ${{ env.RELEASE_REF }} | sed 's/bindings_//')" >> $GITHUB_ENV
+
+      - name: set permissions
+        run: chmod +x ./gradlew 
+
       - name: Publish artifacts
-        working-directory: lwk_bindings/android_bindings
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ./gradlew publish -PlibraryVersion=${{ inputs.package-version }}
+        run: ./gradlew publish -PlibraryVersion=${{ env.RELEASE_VERSION }}

--- a/lwk_bindings/android_bindings/lib/build.gradle.kts
+++ b/lwk_bindings/android_bindings/lib/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("org.gradle.maven-publish")
+    id("maven-publish")
 }
 
 android {
@@ -60,10 +61,20 @@ dependencies {
 
 val libraryVersion: String by project
 publishing {
+    repositories {
+        maven {
+            name = "lwkGitHubPackages"
+            url = uri("https://maven.pkg.github.com/blockstream/lwk")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
     publications {
         create<MavenPublication>("maven") {
             groupId = "com.blockstream"
-            artifactId = "lwk"
+            artifactId = "lwk_bindings"
             version = libraryVersion
 
             afterEvaluate {


### PR DESCRIPTION
1. update github action kotlin script to publish when a new `bindings_*` tag ref is published
2. update android gradle build script to publish on GiHub Packages, requires to set the GITHUB_ACTOR and GITHUB_TOKEN secret variables