### PR TITLE
ci: remove Swatinem cache

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }} -p lwk_bindings
       - run: ls -l target/${{ matrix.target }}/release
 
@@ -79,7 +78,6 @@ jobs:
           name: bindings-x86_64-unknown-linux-gnu
           path: target/
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - run: |
           cargo install uniffi-bindgen-cs --git https://github.com/RCasatta/uniffi-bindgen-cs --rev be29aa170bf9c525edac812c9dd33b1aa801cf3d
           uniffi-bindgen-cs --library target/liblwk.so --out-dir target


### PR DESCRIPTION
CI job fails on  https://github.com/Blockstream/lwk/actions/runs/12377220928/job/34546709406

Try to remove Swatinem cache