### PR TITLE
ci: fix nix build and add cargo test job

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -24,6 +24,16 @@ jobs:
       - run: cargo build
       - run: cargo build --features serial
 
+  test:
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      - run: cargo test --workspace --exclude lwk_test_util --lib
+      - run: cargo test --features serial --workspace --exclude lwk_test_util --lib
+
   nix:
     runs-on: ubuntu-latest
     steps:
@@ -64,4 +74,3 @@ jobs:
         with:
           name: csharp-windows
           path: target/release/csharp
-

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
           # remember, `set1 // set2` does a shallow merge:
           bin = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
-            cargoTestExtraArgs = "--lib"; # only unit testing, integration testing has more requirements (docker and other executables)
+            cargoTestExtraArgs = "--workspace --exclude lwk_tiny_jrpc --lib"; # only unit testing, integration testing has more requirements (docker and other executables)
 
             # Without the following also libs are included in the package, and we need to produce only the executable.
             # There should probably a way to avoid creating it in the first place, but for now this works.
@@ -126,4 +126,3 @@
         }
       );
 }
-


### PR DESCRIPTION
I think the `nix build` job was failing because the `http_get` and `http_options` tests were making network requests to local server. Skip the `tiny_jrpc` crate for nix build, and add a CI job that runs cargo test excluding the `test_util` crate. 