### PR TITLE
tiny_jrpc: remove reqwest dev dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,6 @@ dependencies = [
  "anyhow",
  "jsonrpc 0.17.0",
  "log",
- "reqwest",
  "serde",
  "serde_derive",
  "serde_json",

--- a/lwk_tiny_jrpc/Cargo.toml
+++ b/lwk_tiny_jrpc/Cargo.toml
@@ -17,12 +17,4 @@ tiny_http = "0.12.0"
 log.workspace = true
 
 [dev-dependencies]
-reqwest = { version = "0.12", default-features = false, features = [
-    "charset",
-    "http2",
-    "macos-system-configuration",
-    "blocking",
-    "json",
-    "rustls-tls",
-] }
 tempfile = "3.8.0"


### PR DESCRIPTION
The dep is causing issues in the nix env where the builder fails presumably trying to get the TLS stack. Even removing the TLS features from the dep the error persist, presumably because reqwest is used in other crates and the feature is loaded anyway.
The library is replaced by using TCPStream directly, vibe coded with Claudio.

Replace #71 