### PR TITLE
Expose `get_headers` and `get_transactions` Esplora methods

### DIFF
--- a/lwk_wollet/src/clients/asyncr/esplora.rs
+++ b/lwk_wollet/src/clients/asyncr/esplora.rs
@@ -100,7 +100,7 @@ impl EsploraClient {
         Ok(tx)
     }
 
-    pub(crate) async fn get_transactions(
+    pub async fn get_transactions(
         &self,
         txids: &[Txid],
     ) -> Result<Vec<elements::Transaction>, Error> {
@@ -111,7 +111,7 @@ impl EsploraClient {
         Ok(result)
     }
 
-    pub(crate) async fn get_headers(
+    pub async fn get_headers(
         &self,
         heights: &[Height],
         height_blockhash: &HashMap<Height, BlockHash>,


### PR DESCRIPTION
Would it be possible to expose these two methods?
In particular the `get_transactions` one, as neither this nor the `get_transaction` method are exposed, meaning we can't fetch txs using async Esplora. 
Thanks!