### PR TITLE
ci: bump ubuntu version to 22.04

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -25,7 +25,7 @@ jobs:
       - run: cargo build --features serial
 
   nix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -11,7 +11,7 @@ name: Build & Publish framework for Kotlin library
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Show default version of NDK"
         run: echo $ANDROID_NDK_ROOT
@@ -54,7 +54,7 @@ jobs:
           retention-days: 1
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     if: startsWith(github.ref, 'refs/tags/bindings_')
     steps:


### PR DESCRIPTION
GitHub action fails for  legacy version `Ubuntu 20.04 retirement`: https://github.com/Blockstream/lwk/actions/runs/14613648306 .

Bump ubuntu version to use the 22.04.