### PR TITLE
Merge timestamps in tip only update

### DIFF
--- a/lwk_wollet/src/persister.rs
+++ b/lwk_wollet/src/persister.rs
@@ -175,6 +175,9 @@ impl Persister for FsPersister {
                     // overwrite last update instead of creating a new file.
                     // But we need to update the wallet status so that there will be no problem in reapplying it
                     update.wollet_status = prev_update.wollet_status;
+
+                    // We need to merge the timestamps to be consistent with the wallet status
+                    update.timestamps = vec![prev_update.timestamps, update.timestamps].concat();
                     inner.next = (inner.next.0 - 1).into() // safety: next is at least 1 or last() would be None
                 }
             }


### PR DESCRIPTION
In case we overriding the tip only we should ensure the update fields are consistent with the current wallet status. This is for the next updates to use the correct state.
For subsequent tip only update we should also merge the timestamps as they are considered (and also merged) into the wallet state.

fixes https://github.com/Blockstream/lwk/issues/89