### PR TITLE
Update async_sleep to be non-web compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,10 +2346,10 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio_with_wasm",
  "url",
  "wasm-bindgen-futures",
  "waterfalls",
- "web-sys",
 ]
 
 [[package]]
@@ -3941,6 +3941,30 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42d20f41cbfe26740d0c2fb320d44ce7dfa716be135cb663e99a48248a0e897"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499ed9d797c376545920fa64c39c3efb34217ba4db826102db6c3912555291c9"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/lwk_wollet/Cargo.toml
+++ b/lwk_wollet/Cargo.toml
@@ -42,6 +42,9 @@ reqwest = { version = "0.12", optional = true, default-features = false, feature
     "json",
     "rustls-tls",
 ] }
+tokio_with_wasm = { version = "=0.8.2", features = [
+    "time",
+] }
 
 
 #registry
@@ -74,7 +77,6 @@ tokio = { version = "1.36.0", default-features = false, features = [
 ] }
 # wasm
 wasm-bindgen-futures = { version = "0.4.41" }
-web-sys = { version = "0.3.68", features = ["Window"] }
 js-sys = { version = "0.3.68" }
 
 [dev-dependencies]


### PR DESCRIPTION
The usage of `web_sys::window` for the Wasm `async_sleep` fn is causing non-web use (e.g. node.js) to panic. This PR replaces the use of `web_sys::window` with `tokio_with_wasm`, which replaces the `tokio` sleep fn with a Wasm compatible fn.