### PR TITLE
Return esplora broadcast response in error

### DIFF
--- a/lwk_wollet/src/clients/asyncr/esplora.rs
+++ b/lwk_wollet/src/clients/asyncr/esplora.rs
@@ -94,7 +94,12 @@ impl EsploraClient {
             .body(tx_hex)
             .send()
             .await?;
-        let txid = elements::Txid::from_str(&response.text().await?)?;
+        let text = response.text().await?;
+        let txid = elements::Txid::from_str(&text).map_err(|e| {
+            crate::Error::Generic(format!(
+                "Failed to parse response to txid. Response: {text}, Error: {e}"
+            ))
+        })?;
         Ok(txid)
     }
 


### PR DESCRIPTION
This adds to the broadcast error the original response in case it can't be parsed into a `Txid`, which is the case when the esplora endpoint returns an error.