### PR TITLE
fix: improve error message for esplora broadcast

### DIFF
--- a/lwk_wollet/src/clients/asyncr/esplora.rs
+++ b/lwk_wollet/src/clients/asyncr/esplora.rs
@@ -94,7 +94,9 @@ impl EsploraClient {
             .body(tx_hex)
             .send()
             .await?;
-        let txid = elements::Txid::from_str(&response.text().await?)?;
+        let response_text = response.text().await?;
+        let txid = elements::Txid::from_str(&response_text)
+            .map_err(|_| Error::Generic(format!("broadcast: {response_text}")))?;
         Ok(txid)
     }
 


### PR DESCRIPTION
Broadcast errors are not properly propagated.

Current error looks like this:
`HexToArrayError(InvalidLength(InvalidLengthError { expected: 64, invalid: 84 }))`