### PR TITLE
Ensure last_unused index is monotonic

### DIFF
--- a/lwk_wollet/src/update.rs
+++ b/lwk_wollet/src/update.rs
@@ -240,13 +240,13 @@ impl Wollet {
             store
                 .cache
                 .last_unused_external
-                .store(last_used_external + 1, atomic::Ordering::Relaxed);
+                .fetch_max(last_used_external + 1, atomic::Ordering::Relaxed);
         }
         if let Some(last_used_internal) = last_used_internal {
             store
                 .cache
                 .last_unused_internal
-                .store(last_used_internal + 1, atomic::Ordering::Relaxed);
+                .fetch_max(last_used_internal + 1, atomic::Ordering::Relaxed);
         }
 
         if do_persist {

--- a/lwk_wollet/tests/e2e.rs
+++ b/lwk_wollet/tests/e2e.rs
@@ -324,8 +324,15 @@ fn address() {
     assert_eq!(last_address.index(), gap_limit);
     let mid_address = Some(mid_address.address().clone());
     let last_address = Some(last_address.address().clone());
-    wallet.fund(&server, satoshi, mid_address, None);
+    wallet.fund(&server, satoshi, mid_address.clone(), None);
     wallet.fund(&server, satoshi, last_address, None);
+    let last_unused_before = wallet.address_result(None).index();
+    wallet.fund(&server, satoshi, mid_address, None);
+    let last_unused_after = wallet.address_result(None).index();
+    assert!(
+        last_unused_before <= last_unused_after,
+        "last_unused_before: {last_unused_before}, last_unused_after: {last_unused_after}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
The `last_unused` index was incorrectly recalculated from scratch on every update. This could cause the index to decrease if an update only contained transactions involving older addresses, potentially leading to address reuse.