### PR TITLE
Add input limit check to prevent secp256k1-zkp panic when >256 inputs

### DIFF
--- a/lwk_wollet/src/error.rs
+++ b/lwk_wollet/src/error.rs
@@ -227,6 +227,9 @@ pub enum Error {
 
     #[error("Issuance amount greater than 21M*10^8 are not allowed")]
     IssuanceAmountGreaterThanBtcMax,
+
+    #[error("Number of transaction inputs ({0}) exceeds maximum allowed input count of 256")]
+    TooManyInputs(usize),
 }
 
 // cannot derive automatically with this error because of trait bound

--- a/lwk_wollet/src/pset_create.rs
+++ b/lwk_wollet/src/pset_create.rs
@@ -13,6 +13,8 @@ use elements::pset::elip100::{AssetMetadata, TokenMetadata};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+const SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS: usize = 256;
+
 #[derive(Debug, Serialize, Deserialize)]
 // We make issuance and reissuance are mutually exclusive for simplicity
 pub enum IssuanceRequest {
@@ -74,6 +76,10 @@ impl Wollet {
         inp_weight: &mut usize,
         utxo: &WalletTxOut,
     ) -> Result<usize, Error> {
+        if pset.inputs().len() >= SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS {
+            return Err(Error::TooManyInputs(pset.inputs().len()));
+        }
+
         let mut input = Input::from_prevout(utxo.outpoint);
         let mut txout = self.get_txout(&utxo.outpoint)?;
         let (Some(value_comm), Some(asset_gen)) =


### PR DESCRIPTION
This PR addresses issue #95 where attempting to create a transaction with more than 256 inputs causes a panic due to secp256k1-zkp's internal limit on the number of surjection proof inputs.

Specifically:
- The limit `SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS` (256) is now enforced across transaction creation logic.

- Checks are inserted before every possible call to add_input or input addition logic in `finish` and `finish_liquidex_take`

If the limit is reached, a `TooManyInputs` error is returned instead of panicking.