### PR TITLE
wollet: reunblind

### DIFF
--- a/lwk_wollet/tests/e2e.rs
+++ b/lwk_wollet/tests/e2e.rs
@@ -2978,5 +2978,12 @@ fn test_sync_high_index() {
     assert_eq!(txs.len(), 1);
     assert_eq!(2, txs[0].outputs.iter().filter(|o| o.is_some()).count());
 
+    // w3 unblinds all txout again
+    w3.reunblind().unwrap();
+    // w3 now sees everything
+    let txs = w3.transactions().unwrap();
+    assert_eq!(txs.len(), 1);
+    assert_eq!(2, txs[0].outputs.iter().filter(|o| o.is_some()).count());
+
     rt.block_on(test_env.shutdown());
 }


### PR DESCRIPTION
An alternative and less impactful way of solving https://github.com/Blockstream/lwk/issues/102

Wallets suffering this issue should be fairly rare, and so we don't think it's worth doing invasive changes to the sync/download/unblind code rn.
This change does not prevent us from doing those changes in the future.

We plan to add a new function that lists utxos that have a scriptpubkey that belongs to the wallet, but that cannot be unblinded, eg `fn utxos_cannot_unblind -> Vec<OutPoint>`.
This should happen soon.

cc @hydra-yse 