### PR TITLE
bindings: add `unconfidential_address` function to txout struct

### DIFF
--- a/lwk_bindings/src/blockdata/tx_out.rs
+++ b/lwk_bindings/src/blockdata/tx_out.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::{AssetId, SecretKey},
-    LwkError, Script, TxOutSecrets,
+    Address, LwkError, Network, Script, TxOutSecrets,
 };
 use std::sync::Arc;
 
@@ -41,6 +41,16 @@ impl TxOut {
     /// If explicit returns the value, if confidential [None]
     pub fn value(&self) -> Option<u64> {
         self.inner.value.explicit()
+    }
+
+    /// Unconfidential address
+    pub fn unconfidential_address(&self, network: &Network) -> Option<Arc<Address>> {
+        elements::Address::from_script(
+            &self.inner.script_pubkey,
+            None,
+            network.inner.address_params(),
+        )
+        .map(|a| Arc::new(a.into()))
     }
 
     /// Unblind the output

--- a/lwk_bindings/src/network.rs
+++ b/lwk_bindings/src/network.rs
@@ -8,7 +8,7 @@ use crate::{types::AssetId, ElectrumClient, EsploraClient, LwkError, TxBuilder};
 #[derive(uniffi::Object, PartialEq, Eq, Debug, Clone, Copy)]
 #[uniffi::export(Display)]
 pub struct Network {
-    inner: lwk_wollet::ElementsNetwork,
+    pub(crate) inner: lwk_wollet::ElementsNetwork,
 }
 
 impl Display for Network {


### PR DESCRIPTION
The `WalletTx` struct only contains info on outputs that belong to addresses from the wallet, completely missing outputs to external addresses.
https://github.com/Blockstream/lwk/blob/e9d7d750fee3c6d81b363e1f6c2caa1408ddb82a/lwk_wollet/src/model.rs#L52-L63
I'm not sure on how to add such info to the current struct in a backwards-compatible way, so I went for an `address` function on the bindings of the `TxOut` struct, which can be used from foreign languages to populate information on all outputs.
