### PR TITLE
wollet: apply_transaction utility

### DIFF
--- a/lwk_bindings/src/blockdata/block_header.rs
+++ b/lwk_bindings/src/blockdata/block_header.rs
@@ -1,0 +1,52 @@
+use elements::BlockHeader as ElementsBlockHeader;
+
+/// Wrapper over [`elements::BlockHeader`]
+#[derive(uniffi::Object, Debug, Clone)]
+pub struct BlockHeader {
+    inner: ElementsBlockHeader,
+}
+
+impl From<ElementsBlockHeader> for BlockHeader {
+    fn from(inner: ElementsBlockHeader) -> Self {
+        BlockHeader { inner }
+    }
+}
+
+impl From<BlockHeader> for ElementsBlockHeader {
+    fn from(value: BlockHeader) -> Self {
+        value.inner
+    }
+}
+
+#[uniffi::export]
+impl BlockHeader {
+    /// Get the block hash
+    pub fn block_hash(&self) -> String {
+        self.inner.block_hash().to_string()
+    }
+
+    /// Get the previous block hash
+    pub fn prev_blockhash(&self) -> String {
+        self.inner.prev_blockhash.to_string()
+    }
+
+    /// Get the merkle root
+    pub fn merkle_root(&self) -> String {
+        self.inner.merkle_root.to_string()
+    }
+
+    /// Get the block timestamp
+    pub fn time(&self) -> u32 {
+        self.inner.time
+    }
+
+    /// Get the block version
+    pub fn version(&self) -> u32 {
+        self.inner.version
+    }
+
+    /// Get the block height
+    pub fn height(&self) -> u32 {
+        self.inner.height
+    }
+}

--- a/lwk_bindings/src/blockdata/mod.rs
+++ b/lwk_bindings/src/blockdata/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod address;
 pub mod address_result;
+pub mod block_header;
 pub mod external_utxo;
 pub mod out_point;
 pub mod script;

--- a/lwk_bindings/src/electrum_client.rs
+++ b/lwk_bindings/src/electrum_client.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use lwk_wollet::clients::blocking::BlockchainBackend;
 
-use crate::{LwkError, Transaction, Txid, Update, Wollet};
+use crate::{BlockHeader, LwkError, Transaction, Txid, Update, Wollet};
 
 /// Wrapper over [`lwk_wollet::ElectrumClient`]
 #[derive(uniffi::Object, Debug)]
@@ -58,5 +58,10 @@ impl ElectrumClient {
         };
         let mut tx = self.inner.lock()?.get_transactions(&[txid.into()])?;
         Ok(Arc::new(Transaction::from(tx.pop().ok_or_else(err)?)))
+    }
+
+    pub fn tip(&self) -> Result<Arc<BlockHeader>, LwkError> {
+        let tip = self.inner.lock()?.tip()?;
+        Ok(Arc::new(tip.into()))
     }
 }

--- a/lwk_bindings/src/esplora_client.rs
+++ b/lwk_bindings/src/esplora_client.rs
@@ -2,12 +2,12 @@ use std::sync::{Arc, Mutex};
 
 use lwk_wollet::clients::blocking::{self, BlockchainBackend};
 
-use crate::{LwkError, Network, Transaction, Txid, Update, Wollet};
+use crate::{BlockHeader, LwkError, Network, Transaction, Txid, Update, Wollet};
 
 /// Wrapper over [`blocking::EsploraClient`]
 #[derive(uniffi::Object, Debug)]
 pub struct EsploraClient {
-    inner: Mutex<blocking::EsploraClient>,
+    pub(crate) inner: Mutex<blocking::EsploraClient>,
 }
 #[derive(uniffi::Record)]
 pub struct EsploraClientBuilder {
@@ -90,5 +90,11 @@ impl EsploraClient {
             .lock()?
             .full_scan_to_index(&wollet.state(), index)?;
         Ok(update.map(Into::into).map(Arc::new))
+    }
+
+    /// See [`BlockchainBackend::tip`]
+    pub fn tip(&self) -> Result<Arc<BlockHeader>, LwkError> {
+        let tip = self.inner.lock()?.tip()?;
+        Ok(Arc::new(tip.into()))
     }
 }

--- a/lwk_bindings/src/lib.rs
+++ b/lwk_bindings/src/lib.rs
@@ -26,6 +26,7 @@ mod wollet;
 
 pub use blockdata::address::Address;
 pub use blockdata::address_result::AddressResult;
+pub use blockdata::block_header::BlockHeader;
 pub use blockdata::external_utxo::ExternalUtxo;
 pub use blockdata::out_point::OutPoint;
 pub use blockdata::script::Script;

--- a/lwk_bindings/src/wollet.rs
+++ b/lwk_bindings/src/wollet.rs
@@ -4,8 +4,8 @@ use crate::desc::WolletDescriptor;
 use crate::network::Network;
 use crate::types::{AssetId, SecretKey};
 use crate::{
-    AddressResult, ExternalUtxo, ForeignPersisterLink, LwkError, Pset, PsetDetails, Txid, Update,
-    WalletTx, WalletTxOut,
+    AddressResult, BlockHeader, ExternalUtxo, ForeignPersisterLink, LwkError, Pset, PsetDetails,
+    Transaction, Txid, Update, WalletTx, WalletTxOut,
 };
 use std::sync::{MutexGuard, PoisonError};
 use std::{
@@ -76,6 +76,12 @@ impl Wollet {
     pub fn apply_update(&self, update: &Update) -> Result<(), LwkError> {
         let mut wollet = self.inner.lock()?;
         wollet.apply_update(update.clone().into())?;
+        Ok(())
+    }
+
+    pub fn apply_transaction(&self, tip: &BlockHeader, tx: &Transaction) -> Result<(), LwkError> {
+        let mut wollet = self.inner.lock()?;
+        wollet.apply_transaction(tip.clone().into(), tx.clone().into())?;
         Ok(())
     }
 

--- a/lwk_wollet/src/wollet.rs
+++ b/lwk_wollet/src/wollet.rs
@@ -36,7 +36,7 @@ pub struct Wollet {
     pub(crate) config: Config,
     pub(crate) store: Store,
     pub(crate) persister: Arc<dyn Persister + Send + Sync>,
-    descriptor: WolletDescriptor,
+    pub(crate) descriptor: WolletDescriptor,
     // cached value
     max_weight_to_satisfy: usize,
 }


### PR DESCRIPTION
Applications should be able to update the wollets state without doing a full sync. 

This PR adds an `apply_transaction` function which internally constructs an update with that single transaction.

