### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -57,7 +57,7 @@ This simple example highlights the core responsibilities of each LWK component:
 * **Client** 🌐: Fetch blockchain data from the Liquid Network to update the `wollet`.
 
 ## Key Features
-LWK allows to build more complex applications and prodcuts by leveraging its wide range of features:
+LWK allows to build more complex applications and products by leveraging its wide range of features:
 * [x] Send and receive LBTC
 * [x] Send and receive Liquid Issued Assets (e.g. USDT)
 * [x] Send and receive AMP assets (e.g. BMN)


### PR DESCRIPTION
Fix a typo in "products", I find out while reading the docs at https://liquid.net/bootcamp