### PR TITLE
bindings: Apple compliant framework distribution

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -18,9 +18,9 @@ jobs:
           target: aarch64-unknown-linux-gnu
         - os: ubuntu-22.04
           target: x86_64-unknown-linux-gnu
-        - os: macos-14
+        - os: macos-15
           target: aarch64-apple-darwin
-        - os: macos-14
+        - os: macos-15
           target: x86_64-apple-darwin
         - os: windows-2022
           target: x86_64-pc-windows-msvc
@@ -65,7 +65,7 @@ jobs:
           path: |
             target/${{ matrix.target }}/release/liblwk.dylib
             target/${{ matrix.target }}/release/liblwk.a
-        if:  matrix.os == 'macos-14'
+        if:  matrix.os == 'macos-15'
 
   build-cpp:
     needs: build

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -13,7 +13,7 @@ jobs:
   build-test:
     strategy:
       matrix:
-        os: ["macos-14", "ubuntu-22.04", "windows-2022"]
+        os: ["macos-15", "ubuntu-22.04", "windows-2022"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -37,16 +37,16 @@ jobs:
       - run: nix build .
 
   just-swift: # swift framework is built in the lwk-swift repo, here we care `just swift` doesn't brake
-      runs-on: macos-14
+      runs-on: macos-15
       steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@1.85.0
           with:
             targets: x86_64-apple-ios,aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-apple-darwin
-        - run: brew install xcodegen
         - uses: extractions/setup-just@v2
           with:
             just-version: 1.5.0  # optional semver specification, otherwise latest
+        - run: brew install xcodegen
         - run: just swift
 
   csharp:

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -43,6 +43,7 @@ jobs:
         - uses: dtolnay/rust-toolchain@1.85.0
           with:
             targets: x86_64-apple-ios,aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-apple-darwin
+        - run: brew install xcodegen
         - uses: extractions/setup-just@v2
           with:
             just-version: 1.5.0  # optional semver specification, otherwise latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,7 @@ jobs:
   osx-wheels:
     strategy:
       matrix:
-        os: ["macos-14"]
+        os: ["macos-15"]
     runs-on: ${{ matrix.os }}
     steps:
      - uses: actions/checkout@v4

--- a/justfile
+++ b/justfile
@@ -125,10 +125,10 @@ aarch64-apple-ios-sim:
 swift: ios ios-sim
     # we are not using build-bindings-lib because we need the mac targets anyway
     cargo run --features bindings -- generate --library ./target/aarch64-apple-ios/release/liblwk.a --language swift --out-dir ./target/swift
-    mkdir -p ./target/swift/include
-    mv target/swift/lwkFFI.h target/swift/include
-    mv target/swift/lwkFFI.modulemap  target/swift/include/module.modulemap
-    xcodebuild -create-xcframework -library target/lipo-ios-sim/release/liblwk.a -headers target/swift/include -library target/aarch64-apple-ios/release/liblwk.a -headers target/swift/include -output target/lwkFFI.xcframework
+    xcodegen generate --spec lwk_bindings/swift/project.yml
+    xcodebuild archive -project lwk_bindings/swift/LwkBindings.xcodeproj -scheme lwkFFI -archivePath "./target/ios.xcarchive" -sdk iphoneos -destination "generic/platform=iOS"
+    xcodebuild archive -project lwk_bindings/swift/LwkBindings.xcodeproj -scheme lwkFFI -archivePath "./target/ios_sim.xcarchive" -sdk iphonesimulator -destination "generic/platform=iOS Simulator"
+    xcodebuild -create-xcframework -framework "./target/ios.xcarchive/Products/Library/Frameworks/lwkFFI.framework" -framework "./target/ios_sim.xcarchive/Products/Library/Frameworks/lwkFFI.framework" -output "./target/lwkFFI.xcframework"
 
 csharp-windows: build-bindings-lib
     cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.10.0+v0.29.4

--- a/lwk_bindings/swift/project.yml
+++ b/lwk_bindings/swift/project.yml
@@ -1,0 +1,27 @@
+name: LwkBindings
+options:
+  bundleIdPrefix: com.blockstream
+targets:
+  lwkFFI:
+    type: framework
+    platform: iOS
+    deploymentTarget: "13.0"
+    settings:
+      MACH_O_TYPE: staticlib
+      GENERATE_MASTER_OBJECT_FILE: YES
+      GENERATE_INFOPLIST_FILE: YES
+      STRIP_INSTALLED_PRODUCT: NO
+      BUILD_LIBRARIES_FOR_DISTRIBUTION: YES
+      SKIP_INSTALL: NO
+      DEFINES_MODULE: YES
+      ENABLE_BITCODE: NO
+      # Conditional paths:
+      "LIBRARY_SEARCH_PATHS[sdk=iphoneos*]": "../../target/aarch64-apple-ios/release"
+      "LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]": "../../target/lipo-ios-sim/release"
+    sources:
+      - path: "../../target/swift/lwkFFI.h"
+        headerVisibility: public
+    dependencies:
+      # Link the library name. Xcode will look in the search paths defined above.
+      - framework: liblwk.a
+        embed: false


### PR DESCRIPTION
- creating swift bindings
- creating a wrapper project with xcodegen, instead maintain a full .xcproject
- archiving both platforms
- assembling the final xcframework
