### PR TITLE
fix: manually map error type to prevent wrong error

### DIFF
--- a/lwk_simplicity/src/error.rs
+++ b/lwk_simplicity/src/error.rs
@@ -53,7 +53,7 @@ pub enum ProgramError {
 
     /// Returned when the program cannot be pruned against the transaction environment.
     #[error("Failed to prune program: {0}")]
-    Pruning(#[from] simplicityhl::simplicity::bit_machine::ExecutionError),
+    Pruning(simplicityhl::simplicity::bit_machine::ExecutionError),
 
     #[error("Failed to construct a Bit Machine with enough space: {0}")]
     BitMachineCreation(#[from] simplicityhl::simplicity::bit_machine::LimitError),

--- a/lwk_simplicity/src/runner.rs
+++ b/lwk_simplicity/src/runner.rs
@@ -26,7 +26,10 @@ pub fn run_program(
 
     let mut tracker = DefaultTracker::new(satisfied.debug_symbols()).with_log_level(log_level);
 
-    let pruned = satisfied.redeem().prune_with_tracker(env, &mut tracker)?;
+    let pruned = satisfied
+        .redeem()
+        .prune_with_tracker(env, &mut tracker)
+        .map_err(ProgramError::Pruning)?;
     let mut mac = BitMachine::for_program(&pruned)?;
 
     let result = mac.exec(&pruned, env).map_err(ProgramError::Execution)?;


### PR DESCRIPTION
The automapping of ExecutionError to mapping could cause a wrong map in future. This changes it to a manual mapping to avoid future mistakes