### PR TITLE
refactor: remove extraneous pubs

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -23,6 +23,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04' }}
       - run: cargo build
       - run: cargo build --features serial
+      - run: cargo build --features simplicity
       - run: cargo test --lib  # integration tests requires binaries for the test env...
 
   nix:

--- a/lwk_simplicity/src/taproot_pubkey_gen.rs
+++ b/lwk_simplicity/src/taproot_pubkey_gen.rs
@@ -81,7 +81,7 @@ pub fn generate_public_key_without_private() -> (PublicKey, Vec<u8>) {
 ///
 /// # Panics
 /// Panics if the system random number generator fails.
-pub fn get_random_seed() -> [u8; 32] {
+fn get_random_seed() -> [u8; 32] {
     let mut bytes: [u8; 32] = [0; 32];
     thread_rng().fill_bytes(&mut bytes);
     bytes

--- a/lwk_simplicity/src/wallet_abi/schema/mod.rs
+++ b/lwk_simplicity/src/wallet_abi/schema/mod.rs
@@ -6,11 +6,11 @@
 //! - [`types`]: shared envelope support types.
 //! - [`values`]: Simplicity argument/witness serialization helpers.
 
-pub mod runtime_deps;
-pub mod runtime_params;
-pub mod tx_create;
-pub mod types;
-pub mod values;
+mod runtime_deps;
+mod runtime_params;
+mod tx_create;
+mod types;
+mod values;
 
 pub use runtime_deps::{
     KeyStoreMeta, WalletOutputRequest, WalletOutputTemplate, WalletProviderMeta,


### PR DESCRIPTION
Remove (seemingly) unnecessary pubs. 

These functions do not appear to necessitate being public. 