### PR TITLE
Expose authenticated Esplora in the bindings

### DIFF
--- a/docs/src/clients.md
+++ b/docs/src/clients.md
@@ -110,6 +110,14 @@ Use authenticated clients when:
 {{#include ../../lwk_wollet/tests/e2e.rs:authenticated_esplora_client}}
 ```
 </section>
+
+<div slot="title">Python</div>
+<section>
+
+```python
+{{#include ../../lwk_bindings/tests/bindings/authenticated_esplora_client.py:authenticated_esplora_client}}
+```
+</section>
 </custom-tabs>
 
 ## Waterfalls

--- a/lwk_bindings/src/esplora_client.rs
+++ b/lwk_bindings/src/esplora_client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use lwk_wollet::{
@@ -19,6 +20,49 @@ pub struct EsploraClient {
     pub(crate) builder: lwk_wollet::clients::EsploraClientBuilder,
 }
 
+/// Provider of a token for authenticated Esplora and Waterfalls backends.
+///
+/// Some Esplora servers, particularly enterprise deployments like
+/// [Blockstream Enterprise](https://blockstream.info/explorer-api), require authentication for
+/// access.
+#[derive(uniffi::Enum, Debug, Clone)]
+pub enum TokenProvider {
+    /// No token is needed
+    None,
+    /// A static token is used as-is for every request
+    Static {
+        /// The token value
+        token: String,
+    },
+    /// An OAuth2 token is obtained from the Blockstream API and refreshed automatically
+    Blockstream {
+        /// The url to get the token from
+        url: String,
+        /// The client ID
+        client_id: String,
+        /// The client secret
+        client_secret: String,
+    },
+}
+
+impl From<TokenProvider> for lwk_wollet::clients::TokenProvider {
+    fn from(value: TokenProvider) -> Self {
+        match value {
+            TokenProvider::None => lwk_wollet::clients::TokenProvider::None,
+            TokenProvider::Static { token } => lwk_wollet::clients::TokenProvider::Static(token),
+            TokenProvider::Blockstream {
+                url,
+                client_id,
+                client_secret,
+            } => lwk_wollet::clients::TokenProvider::Blockstream {
+                url,
+                client_id,
+                client_secret,
+            },
+        }
+    }
+}
+
 /// A builder for the `EsploraClient`
 #[derive(uniffi::Record)]
 pub struct EsploraClientBuilder {
@@ -32,6 +76,12 @@ pub struct EsploraClientBuilder {
     timeout: Option<u8>,
     #[uniffi(default = false)]
     utxo_only: bool,
+    /// HTTP headers to set on each request, for example to authenticate with a backend
+    #[uniffi(default = None)]
+    headers: Option<HashMap<String, String>>,
+    /// Token provider for authenticated Esplora and Waterfalls backends
+    #[uniffi(default = None)]
+    token_provider: Option<TokenProvider>,
 }
 
 impl From<EsploraClientBuilder> for lwk_wollet::clients::EsploraClientBuilder {
@@ -51,6 +101,12 @@ impl From<EsploraClientBuilder> for lwk_wollet::clients::EsploraClientBuilder {
         }
         if builder.utxo_only {
             result = result.utxo_only(true);
+        }
+        if let Some(headers) = builder.headers {
+            result = result.headers(headers);
+        }
+        if let Some(token_provider) = builder.token_provider {
+            result = result.token_provider(token_provider.into());
         }
         result
     }
@@ -154,5 +210,85 @@ impl EsploraClient {
     #[allow(unused)] // TODO remove once lwk_boltz is integrated
     pub(crate) fn clone_async_client(&self) -> Result<asyncr::EsploraClient, LwkError> {
         Ok(self.builder.clone().build()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lwk_wollet::clients::TokenProvider as CoreTokenProvider;
+
+    // These tests exercise the binding-side authentication wiring offline: building a client
+    // never performs network I/O because the OAuth token is fetched lazily on the first request.
+
+    #[test]
+    fn token_provider_conversion() {
+        assert!(matches!(
+            CoreTokenProvider::from(TokenProvider::None),
+            CoreTokenProvider::None
+        ));
+
+        match CoreTokenProvider::from(TokenProvider::Static {
+            token: "abc".to_string(),
+        }) {
+            CoreTokenProvider::Static(token) => assert_eq!(token, "abc"),
+            other => panic!("expected Static, got {other:?}"),
+        }
+
+        match CoreTokenProvider::from(TokenProvider::Blockstream {
+            url: "https://login".to_string(),
+            client_id: "id".to_string(),
+            client_secret: "secret".to_string(),
+        }) {
+            CoreTokenProvider::Blockstream {
+                url,
+                client_id,
+                client_secret,
+            } => {
+                assert_eq!(url, "https://login");
+                assert_eq!(client_id, "id");
+                assert_eq!(client_secret, "secret");
+            }
+            other => panic!("expected Blockstream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn builder_with_auth_builds_offline() {
+        let base_url = "https://enterprise.blockstream.info/liquid/api".to_string();
+
+        // Blockstream OAuth2 provider
+        let builder = EsploraClientBuilder {
+            base_url: base_url.clone(),
+            network: Network::mainnet(),
+            waterfalls: false,
+            concurrency: None,
+            timeout: None,
+            utxo_only: false,
+            headers: None,
+            token_provider: Some(TokenProvider::Blockstream {
+                url: "https://login".to_string(),
+                client_id: "id".to_string(),
+                client_secret: "secret".to_string(),
+            }),
+        };
+        assert!(EsploraClient::from_builder(builder).is_ok());
+
+        // Static token plus custom headers
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom".to_string(), "value".to_string());
+        let builder = EsploraClientBuilder {
+            base_url,
+            network: Network::mainnet(),
+            waterfalls: false,
+            concurrency: None,
+            timeout: None,
+            utxo_only: false,
+            headers: Some(headers),
+            token_provider: Some(TokenProvider::Static {
+                token: "tok".to_string(),
+            }),
+        };
+        assert!(EsploraClient::from_builder(builder).is_ok());
     }
 }

--- a/lwk_bindings/src/lib.rs
+++ b/lwk_bindings/src/lib.rs
@@ -84,7 +84,7 @@ pub use currency_code::CurrencyCode;
 pub use desc::WolletDescriptor;
 pub use electrum_client::ElectrumClient;
 pub use error::LwkError;
-pub use esplora_client::{EsploraClient, EsploraClientBuilder};
+pub use esplora_client::{EsploraClient, EsploraClientBuilder, TokenProvider};
 pub use liquidex::{AssetAmount, UnvalidatedLiquidexProposal, ValidatedLiquidexProposal};
 pub use mnemonic::Mnemonic;
 pub use network::Network;

--- a/lwk_bindings/tests/bindings.rs
+++ b/lwk_bindings/tests/bindings.rs
@@ -29,6 +29,9 @@ uniffi::build_foreign_language_testcases!(
     "tests/bindings/payment_instructions.py",
     "tests/bindings/fallback_client.py",
     "tests/bindings/serde_roundtrip.py",
+    "tests/bindings/watch_only_wallet.py",
+    "tests/bindings/liquid_change.py",
+    "tests/bindings/authenticated_esplora_client.py",
 );
 
 #[cfg(all(feature = "foreign_bindings", feature = "simplicity"))]

--- a/lwk_bindings/tests/bindings/authenticated_esplora_client.py
+++ b/lwk_bindings/tests/bindings/authenticated_esplora_client.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Authenticated Esplora client with LWK (OAuth2 / static token / headers).
+
+Some Esplora servers — e.g. Blockstream Enterprise — require authentication.
+The bindings expose this through `EsploraClientBuilder`'s `token_provider` and
+`headers` fields.
+
+This script does two things:
+
+  * Offline checks (always run): build authenticated clients and assert the
+    builder wiring behaves as expected. No network or credentials needed,
+    because the OAuth token is only fetched on the first request.
+  * Live check (opt-in): if CLIENT_ID and CLIENT_SECRET are set, actually hit
+    an authenticated endpoint and assert we can read the chain tip. Point it at
+    a different host/login with ESPLORA_BASE_URL / ESPLORA_LOGIN_URL.
+"""
+
+import logging
+import os
+import sys
+
+from lwk import *
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+log = logging.getLogger("authenticated_esplora")
+
+network = Network.mainnet()
+
+client_id = os.environ.get("CLIENT_ID", "your_client_id")
+client_secret = os.environ.get("CLIENT_SECRET", "your_client_secret")
+
+
+def offline_checks():
+    """Build authenticated clients and assert the wiring, without any network."""
+    # ANCHOR: authenticated_esplora_client
+    base_url = "https://enterprise.blockstream.info/liquid/api"
+    login_url = "https://login.blockstream.com/realms/blockstream-public/protocol/openid-connect/token"
+
+    builder = EsploraClientBuilder(
+        base_url=base_url,
+        network=network,
+        token_provider=TokenProvider.BLOCKSTREAM(
+            url=login_url,
+            client_id=client_id,
+            client_secret=client_secret,
+        ),
+    )
+    client = EsploraClient.from_builder(builder)
+    # ANCHOR_END: authenticated_esplora_client
+
+    # The OAuth2 provider is recorded on the builder and the client is built.
+    assert builder.token_provider.is_BLOCKSTREAM()
+    assert client is not None
+    log.info("built OAuth2 (Blockstream) client for %s", base_url)
+
+    # A static token (when you already have one) and/or custom headers also work.
+    builder = EsploraClientBuilder(
+        base_url=base_url,
+        network=network,
+        token_provider=TokenProvider.STATIC(token="my-token"),
+        headers={"X-Custom-Header": "value"},
+    )
+    client = EsploraClient.from_builder(builder)
+
+    assert builder.token_provider.is_STATIC()
+    assert builder.token_provider.token == "my-token"
+    assert builder.headers == {"X-Custom-Header": "value"}
+    assert client is not None
+    log.info("built static-token client with custom headers")
+
+    # No-auth builders must keep working (auth fields default to None).
+    builder = EsploraClientBuilder(base_url=base_url, network=network)
+    assert builder.token_provider is None
+    assert builder.headers is None
+    assert EsploraClient.from_builder(builder) is not None
+    log.info("offline checks passed")
+
+
+def live_check():
+    """If credentials are provided, prove auth works by reading the chain tip."""
+    if client_id == "your_client_id" or client_secret == "your_client_secret":
+        log.info("skipping live check: set CLIENT_ID and CLIENT_SECRET to enable it")
+        return
+
+    base_url = os.environ.get(
+        "ESPLORA_BASE_URL", "https://enterprise.uat.blockstream.info/liquid/api"
+    )
+    login_url = os.environ.get(
+        "ESPLORA_LOGIN_URL",
+        "https://login.uat.blockstream.com/realms/blockstream-public/protocol/openid-connect/token",
+    )
+
+    builder = EsploraClientBuilder(
+        base_url=base_url,
+        network=network,
+        token_provider=TokenProvider.BLOCKSTREAM(
+            url=login_url, client_id=client_id, client_secret=client_secret
+        ),
+        timeout=30,
+    )
+    client = EsploraClient.from_builder(builder)
+
+    log.info("authenticating against %s ...", base_url)
+    tip = client.tip()  # triggers the OAuth token fetch + an authenticated request
+    log.info("authenticated OK: chain tip height=%d hash=%s", tip.height(), tip.block_hash())
+    assert tip.height() > 100, f"unexpected tip height {tip.height()}"
+
+
+def main():
+    offline_checks()
+    try:
+        live_check()
+    except LwkError as e:
+        # A network/credential failure here shouldn't look like a wiring bug.
+        log.error("live check failed (network or credentials): %s", e)
+        return 1
+    log.info("done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lwk_bindings/tests/bindings/authenticated_wallet_scan.py
+++ b/lwk_bindings/tests/bindings/authenticated_wallet_scan.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Non-trivial watch-only test driven by an authenticated Esplora client.
+
+This scans a *real* mainnet Liquid wallet through an authenticated Blockstream
+Enterprise endpoint and asserts non-trivial facts about its on-chain history.
+
+It needs NO private keys: the wallet is watch-only, built from a public CT
+descriptor (an xpub). Scanning only ever reads the chain. The only secrets
+involved are the OAuth2 *API* credentials for the authenticated endpoint, which
+are unrelated to wallet signing keys.
+
+This mirrors the Rust `esplora_authenticated_wallet_scan_*` integration tests:
+it exercises both the plain Esplora and the Waterfalls code paths through the
+authenticated client and checks they agree.
+
+Run it (credentials required):
+
+    CLIENT_ID=... CLIENT_SECRET=... \
+    PYTHONPATH=$PWD/target/release/bindings \
+    python3 lwk_bindings/tests/bindings/authenticated_wallet_scan.py
+
+Override the endpoint/realm with ESPLORA_BASE_URL / ESPLORA_LOGIN_URL
+(defaults target the production enterprise endpoint). For UAT, e.g.:
+
+    ESPLORA_BASE_URL=https://enterprise.uat.blockstream.info/liquid/api
+    ESPLORA_LOGIN_URL=https://login.uat.blockstream.com/realms/blockstream-public/protocol/openid-connect/token
+"""
+
+import logging
+import os
+import sys
+
+from lwk import *
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+log = logging.getLogger("authenticated_wallet_scan")
+
+# A mainnet (coin type 1776) watch-only wp2kh descriptor with known USDt history.
+# Same descriptor used by the Rust authenticated-scan integration tests; it has
+# more than 16 transactions on chain. No private key material here.
+DESCRIPTOR = (
+    "ct(slip77(2411e278affa5c47010eab6d313c1ec66628ec0dd03b6fc98d1a05a0618719e6),"
+    "elwpkh([a8874235/84'/1776'/0']xpub6DLHCiTPg67KE9ksCjNVpVHTRDHzhCSmoBTKzp2K4Fx"
+    "LQwQvvdNzuqxhK2f9gFVCN6Dori7j2JMLeDoB4VqswG7Et9tjqauAvbDmzF8NEPH/<0;1>/*))"
+    "#upsg7h8m"
+)
+
+MIN_TXS = 16  # the wallet has more than this many transactions on chain
+
+BASE_URL = os.environ.get(
+    "ESPLORA_BASE_URL", "https://enterprise.blockstream.info/liquid/api"
+)
+LOGIN_URL = os.environ.get(
+    "ESPLORA_LOGIN_URL",
+    "https://login.blockstream.com/realms/blockstream-public/protocol/openid-connect/token",
+)
+
+
+def make_client(network, *, waterfalls):
+    """Build an authenticated Esplora (or Waterfalls) client."""
+    client_id = os.environ["CLIENT_ID"]
+    client_secret = os.environ["CLIENT_SECRET"]
+    # The Waterfalls API is served under a `/waterfalls` sub-path of the
+    # enterprise endpoint, e.g. `.../liquid/api/waterfalls`.
+    base_url = BASE_URL.rstrip("/") + "/waterfalls" if waterfalls else BASE_URL
+    builder = EsploraClientBuilder(
+        base_url=base_url,
+        network=network,
+        waterfalls=waterfalls,
+        timeout=30,
+        token_provider=TokenProvider.BLOCKSTREAM(
+            url=LOGIN_URL, client_id=client_id, client_secret=client_secret
+        ),
+    )
+    return EsploraClient.from_builder(builder)
+
+
+def invalid_creds_check(network):
+    """An authenticated request with bad credentials must error clearly.
+
+    This needs network but neither valid credentials nor credits: the OAuth
+    token request itself is rejected, so `tip()` must raise rather than return.
+    """
+    builder = EsploraClientBuilder(
+        base_url=BASE_URL,
+        network=network,
+        timeout=30,
+        token_provider=TokenProvider.BLOCKSTREAM(
+            url=LOGIN_URL,
+            client_id="definitely-not-a-real-client",
+            client_secret="definitely-not-a-real-secret",
+        ),
+    )
+    client = EsploraClient.from_builder(builder)
+    try:
+        client.tip()
+    except LwkError as e:
+        log.info("invalid credentials correctly rejected: %s", e)
+        return
+    raise AssertionError("expected an error when using invalid credentials")
+
+
+def scan(network, *, waterfalls):
+    """Watch-only full scan through the authenticated client; return the wallet."""
+    label = "waterfalls" if waterfalls else "esplora"
+    client = make_client(network, waterfalls=waterfalls)
+
+    # Reading the tip forces the OAuth token fetch and proves auth works.
+    tip = client.tip()
+    log.info("[%s] authenticated; chain tip height=%d", label, tip.height())
+    assert tip.height() > 100, f"[{label}] unexpected tip height {tip.height()}"
+
+    wollet = Wollet(network, WolletDescriptor(DESCRIPTOR), datadir=None)
+    update = client.full_scan(wollet)
+    assert update is not None, f"[{label}] expected the first scan to return an update"
+    wollet.apply_update(update)
+
+    txs = wollet.transactions()
+    balance = wollet.balance()
+    utxos = wollet.utxos()
+    log.info(
+        "[%s] scanned: %d txs, %d assets, %d utxos",
+        label, len(txs), len(balance), len(utxos),
+    )
+    for asset, amount in balance.items():
+        log.info("[%s]   balance %s = %d", label, asset, amount)
+
+    # ---- non-trivial assertions about the recovered on-chain state ----
+    assert len(txs) > MIN_TXS, f"[{label}] expected > {MIN_TXS} txs, got {len(txs)}"
+
+    # Every UTXO must be confidential and consistent with the wallet.
+    for utxo in utxos:
+        secrets = utxo.unblinded()
+        assert secrets.value() >= 0
+        assert utxo.ext_int() in (Chain.EXTERNAL, Chain.INTERNAL)
+        assert balance.get(secrets.asset(), 0) >= secrets.value()
+
+    # Balance is the sum of UTXO values per asset (sanity-check the accounting).
+    by_asset = {}
+    for utxo in utxos:
+        s = utxo.unblinded()
+        by_asset[s.asset()] = by_asset.get(s.asset(), 0) + s.value()
+    assert by_asset == dict(balance), f"[{label}] utxo sums {by_asset} != balance {dict(balance)}"
+
+    # Transactions are ordered/queryable and round-trip by txid.
+    first = txs[0]
+    assert str(wollet.transaction(first.txid()).txid()) == str(first.txid())
+
+    return wollet
+
+
+def main():
+    if not os.environ.get("CLIENT_ID") or not os.environ.get("CLIENT_SECRET"):
+        log.info("skipping: set CLIENT_ID and CLIENT_SECRET to run the authenticated scan")
+        return 0
+
+    network = Network.mainnet()
+    try:
+        # Negative path: bad credentials must fail clearly.
+        invalid_creds_check(network)
+        # Positive path: scan via both code paths with valid credentials.
+        w_esplora = scan(network, waterfalls=False)
+        w_waterfalls = scan(network, waterfalls=True)
+    except LwkError as e:
+        log.error("authenticated scan failed (network or credentials): %s", e)
+        return 1
+
+    # The two independent code paths must agree on the wallet's balance.
+    assert w_esplora.balance() == w_waterfalls.balance(), (
+        f"esplora {w_esplora.balance()} != waterfalls {w_waterfalls.balance()}"
+    )
+    log.info("esplora and waterfalls scans agree; OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lwk_bindings/tests/bindings/liquid_change.py
+++ b/lwk_bindings/tests/bindings/liquid_change.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Demonstrate how change is handled on Liquid with LWK.
+
+Liquid transactions are confidential: amounts and assets are blinded, so the
+"change" that a transaction returns to your own wallet is not visible to the
+outside world. This example sends a partial payment and then inspects the
+resulting transaction to show:
+
+  * which output is the change (it belongs to the wallet's *internal* chain),
+  * that the change amount equals funded - sent - fee,
+  * that the change is confidential but the wallet can unblind it,
+  * that change lands on a fresh internal address each time (no reuse),
+  * that the change becomes a new spendable UTXO.
+
+It runs against a throwaway regtest node (elementsd + electrs) started by
+LwkTestEnv, so it needs no network access and no credentials.
+"""
+
+from lwk import *
+
+
+def wallet_outputs(wtx):
+    """Return (vout, WalletTxOut) pairs for outputs owned by the wallet.
+
+    `WalletTx.outputs()` yields `None` for outputs that don't belong to the
+    wallet (the recipient and the explicit fee output), and a `WalletTxOut`
+    for the ones that do.
+    """
+    return [(vout, out) for vout, out in enumerate(wtx.outputs()) if out is not None]
+
+
+def main():
+    node = LwkTestEnv()  # launches elementsd + electrs
+
+    network = Network.regtest_default()
+    policy_asset = network.policy_asset()
+    client = ElectrumClient.from_url(node.electrum_url())
+
+    signer = Signer(Mnemonic.from_random(12), network)
+    wollet = Wollet(network, signer.wpkh_slip77_descriptor(), datadir=None)
+
+    # ----------------------------------------------------------------- fund
+    # Fund the wallet with a single confidential UTXO.
+    funded = 100_000
+    txid = node.send_to_address(wollet.address(0).address(), funded, asset=None)
+    wollet.wait_for_tx(txid, client)
+    assert wollet.balance()[policy_asset] == funded
+    assert len(wollet.utxos()) == 1
+
+    # -------------------------------------------------------------- payment
+    # Spend less than we have, which forces a change output back to ourselves.
+    sent = 30_000
+    destination = node.get_new_address()
+
+    builder = network.tx_builder()
+    builder.add_lbtc_recipient(destination, sent)
+    pset = builder.finish(wollet)
+    pset = signer.sign(pset)
+    tx = wollet.finalize(pset).extract_tx()
+    fee = tx.fee(policy_asset)
+
+    txid = client.broadcast(tx)
+    wollet.wait_for_tx(txid, client)
+
+    # ------------------------------------------------------ inspect change
+    wtx = wollet.transaction(txid)
+    owned = wallet_outputs(wtx)
+
+    # The recipient output and the fee output are not ours, so exactly one of
+    # the transaction's outputs comes back to the wallet: the change.
+    assert len(owned) == 1, f"expected 1 change output, got {len(owned)}"
+    change_vout, change = owned[0]
+
+    # Change always goes to the *internal* chain, never the external chain that
+    # we hand out to payers.
+    assert change.ext_int() == Chain.INTERNAL
+
+    # It is confidential on-chain, but as the owner we can read the blinded
+    # secrets. The change amount is whatever is left after the payment and fee.
+    secrets = change.unblinded()
+    expected_change = funded - sent - fee
+    assert secrets.value() == expected_change
+    assert secrets.asset() == policy_asset
+    assert not secrets.is_explicit()  # blinded, i.e. a real confidential output
+
+    # Sanity-check the raw transaction: the value committed on-chain is a
+    # Pedersen commitment, not the cleartext amount we just recovered.
+    raw_change_out = tx.outputs()[change_vout]
+    assert not raw_change_out.is_fee()
+
+    print(f"funded            : {funded:>8} sats")
+    print(f"sent to node      : {sent:>8} sats")
+    print(f"network fee       : {fee:>8} sats")
+    print(f"change (recovered): {secrets.value():>8} sats -> {change.address()}")
+    print(f"change chain/index: {change.ext_int()} #{change.wildcard_index()}")
+
+    # The wallet balance and the spendable UTXO set now reflect the change.
+    assert wollet.balance()[policy_asset] == expected_change
+    utxos = wollet.utxos()
+    assert len(utxos) == 1
+    assert str(utxos[0].outpoint().txid()) == str(txid)
+    assert utxos[0].outpoint().vout() == change_vout
+
+    # ----------------------------------------- change uses fresh addresses
+    # Spend again and confirm the new change does not reuse the previous
+    # internal address (address reuse would harm privacy).
+    builder = network.tx_builder()
+    builder.add_lbtc_recipient(node.get_new_address(), 5_000)
+    pset = signer.sign(builder.finish(wollet))
+    tx2 = wollet.finalize(pset).extract_tx()
+    txid2 = client.broadcast(tx2)
+    wollet.wait_for_tx(txid2, client)
+
+    _, change2 = wallet_outputs(wollet.transaction(txid2))[0]
+    assert change2.ext_int() == Chain.INTERNAL
+    assert str(change2.address()) != str(change.address())
+    assert change2.wildcard_index() != change.wildcard_index()
+    print(f"second change addr: {change2.address()} #{change2.wildcard_index()} (fresh)")
+
+    print("OK: confidential change handled correctly")
+
+
+if __name__ == "__main__":
+    main()

--- a/lwk_bindings/tests/bindings/watch_only_wallet.py
+++ b/lwk_bindings/tests/bindings/watch_only_wallet.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Watch-only wallet workflow with LWK (online watcher + offline signer).
+
+In LWK a `Wollet` is *always* watch-only: it is built from a Confidential
+Transaction (CT) descriptor and never holds any private key. Spending is a
+separate step performed by a `Signer`. That separation is exactly what you want
+for an air-gapped / cold-storage setup:
+
+    offline (cold)                         online (hot, untrusted)
+    ------------------                     ------------------------
+    Signer (holds the seed)                Wollet (descriptor only)
+        |  export public descriptor  ->        derive addresses
+        |                                       scan the chain
+        |                                       build an unsigned PSET
+        |  <- transfer unsigned PSET ----  --
+      sign the PSET
+        -- transfer signed PSET ->  ------>    finalize + broadcast
+
+This example plays both roles in one process to show the data that crosses the
+boundary. The online wallet is reconstructed purely from the descriptor *string*
+to make the point that no key material is ever needed to watch or to build a
+transaction.
+
+Runs against a throwaway regtest node (elementsd + electrs) started by
+LwkTestEnv; no network access or credentials required.
+"""
+
+from lwk import *
+
+
+def main():
+    node = LwkTestEnv()  # launches elementsd + electrs
+
+    network = Network.regtest_default()
+    policy_asset = network.policy_asset()
+    client = ElectrumClient.from_url(node.electrum_url())
+
+    # ----------------------------------------------------- offline: the key
+    # The signer lives offline. The only thing it ever exports is the *public*
+    # CT descriptor; the mnemonic/seed never leaves this side.
+    signer = Signer(Mnemonic.from_random(12), network)
+    exported_descriptor = str(signer.wpkh_slip77_descriptor())
+
+    # ------------------------------------------------- online: the watcher
+    # The online wallet is built from the descriptor string alone. It has no
+    # signer and no seed: it can only watch and prepare transactions.
+    descriptor = WolletDescriptor(exported_descriptor)
+    watch_only = Wollet(network, descriptor, datadir=None)
+
+    # A watch-only wallet can hand out receive addresses without any key.
+    receive = watch_only.address(0)
+    assert receive.index() == 0
+    print(f"watch-only receive address #0: {receive.address()}")
+
+    # Fund it and scan: balances are visible to the watcher.
+    funded = 100_000
+    txid = node.send_to_address(receive.address(), funded, asset=None)
+    watch_only.wait_for_tx(txid, client)
+    assert watch_only.balance()[policy_asset] == funded
+    assert len(watch_only.utxos()) == 1
+    print(f"watch-only balance after funding: {watch_only.balance()[policy_asset]} sats")
+
+    # ----------------------------------------- online: build unsigned PSET
+    sent = 25_000
+    destination = node.get_new_address()
+
+    builder = network.tx_builder()
+    builder.add_lbtc_recipient(destination, sent)
+    unsigned_pset = builder.finish(watch_only)
+
+    # The PSET is unsigned: the wallet could not have signed it even if asked.
+    details = watch_only.pset_details(unsigned_pset)
+    sigs = details.signatures()
+    assert all(len(s.has_signature()) == 0 for s in sigs), "watch-only must not sign"
+    # ...but the watcher can still verify *what* it is about to send.
+    recipients = details.balance().recipients()
+    assert len(recipients) == 1
+    assert recipients[0].value() == sent
+    print(f"unsigned PSET: sending {recipients[0].value()} sats, "
+          f"fee {details.balance().fee()} sats")
+
+    # The unsigned PSET is what you would move to the cold device (QR, file, …).
+    pset_for_signing = Pset(str(unsigned_pset))
+
+    # ------------------------------------------------------ offline: sign
+    # On the cold side, the signer reconstructs/holds the seed and signs. It
+    # needs nothing from the online wallet except the PSET bytes.
+    signed_pset = signer.sign(pset_for_signing)
+
+    after = watch_only.pset_details(signed_pset)
+    assert any(len(s.has_signature()) > 0 for s in after.signatures()), "now signed"
+
+    # ------------------------------------------ online: finalize + broadcast
+    finalized = watch_only.finalize(signed_pset)
+    tx = finalized.extract_tx()
+    fee = tx.fee(policy_asset)
+    txid = client.broadcast(tx)
+    watch_only.wait_for_tx(txid, client)
+
+    expected = funded - sent - fee
+    assert watch_only.balance()[policy_asset] == expected
+    print(f"broadcast {txid}; watch-only balance now {expected} sats")
+
+    # ----------------------------------- a second, independent watch-only
+    # Any number of watchers can be reconstructed from the same descriptor and
+    # will agree on history/balance without ever touching a key.
+    another_watcher = Wollet(network, WolletDescriptor(exported_descriptor), datadir=None)
+    another_watcher.wait_for_tx(txid, client)
+    assert another_watcher.balance()[policy_asset] == watch_only.balance()[policy_asset]
+
+    print("OK: watch-only watched, prepared, and verified; signer signed offline")
+
+
+if __name__ == "__main__":
+    main()

--- a/lwk_wollet/src/clients/asyncr/esplora.rs
+++ b/lwk_wollet/src/clients/asyncr/esplora.rs
@@ -1198,7 +1198,7 @@ async fn fetch_oauth_token(
     client_id: &str,
     client_secret: &str,
 ) -> Result<String, Error> {
-    let token_response: serde_json::Value = client
+    let response = client
         .post(url)
         .header("Content-Type", "application/x-www-form-urlencoded")
         .form(&[
@@ -1208,9 +1208,16 @@ async fn fetch_oauth_token(
             ("scope", "openid"),
         ])
         .send()
-        .await?
-        .json()
         .await?;
+
+    // Surface OAuth/HTTP errors from the token endpoint (e.g. a 401 with
+    // `{"error":"invalid_client"}` for bad credentials) instead of falling
+    // through to a generic "missing access_token" message below.
+    if !response.status().is_success() {
+        return Err(error_for_status(url, response).await);
+    }
+
+    let token_response: serde_json::Value = response.json().await?;
 
     let token = token_response["access_token"]
         .as_str()

--- a/lwk_wollet/src/clients/asyncr/esplora.rs
+++ b/lwk_wollet/src/clients/asyncr/esplora.rs
@@ -945,6 +945,11 @@ impl EsploraClient {
                 let mut cached_token = self.token.lock().await;
                 *cached_token = None;
                 attempt += 1;
+            } else if !response.status().is_success() {
+                // Surface the server's status and message instead of letting
+                // callers misparse an error body (e.g. a JSON `{"error": ...}`)
+                // as the expected success payload.
+                return Err(error_for_status(url, response).await);
             } else {
                 return Ok(response);
             }
@@ -1014,6 +1019,11 @@ impl EsploraClient {
                 let mut cached_token = self.token.lock().await;
                 *cached_token = None;
                 attempt += 1;
+            } else if !response.status().is_success() {
+                // Surface the server's status and message instead of letting
+                // callers misparse an error body (e.g. a JSON `{"error": ...}`)
+                // as the expected success payload.
+                return Err(error_for_status(url, response).await);
             } else {
                 return Ok(response);
             }
@@ -1164,6 +1174,21 @@ fn encrypt(plaintext: &str, recipient: Recipient) -> Result<String, Error> {
     writer.finish()?;
     let result = base64::prelude::BASE64_STANDARD_NO_PAD.encode(encrypted);
     Ok(result)
+}
+
+/// Builds an [`Error`] describing an unsuccessful HTTP response, including the
+/// status code and (a bounded prefix of) the response body so failures like an
+/// authenticated backend returning `402 Insufficient credits` are reported
+/// clearly rather than as a downstream JSON parsing error.
+async fn error_for_status(url: &str, response: Response) -> Error {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    let snippet: String = body.trim().chars().take(500).collect();
+    if snippet.is_empty() {
+        Error::Generic(format!("{url} returned HTTP {status}"))
+    } else {
+        Error::Generic(format!("{url} returned HTTP {status}: {snippet}"))
+    }
 }
 
 /// Fetches an OAuth2 access token using client credentials flow


### PR DESCRIPTION
## Expose authenticated Esplora in the bindings

### Motivation
`lwk_wollet` already supports authenticated Esplora/Waterfalls backends (OAuth2, static token, custom headers), but the UniFFI bindings didn't expose any of it — so Python/Kotlin/Swift/C#/Go consumers couldn't connect to authenticated Blockstream Enterprise endpoints. While wiring this up, the work also surfaced a robustness gap: the Esplora client reported authenticated failures (e.g. `402 Insufficient credits`) as a misleading `invalid type: map, expected a sequence` JSON error.

### What's in here
- **bindings: authenticated Esplora access.** New `TokenProvider` enum (`None` / `Static` / `Blockstream` OAuth2) plus `headers` and `token_provider` fields on `EsploraClientBuilder`, wired through to the core builder. Both fields are optional with defaults, so this is additive — existing `EsploraClientBuilder(...)` calls are unchanged.
- **wollet: surface HTTP errors.** `get_with_retry`/`post_with_retry` now fail fast on any non-2xx status, returning the status code and response body instead of letting callers misparse an error payload. Behavioral change to existing methods (`tip`, `full_scan`, `broadcast`), but only in the error path.
- **docs + examples.** A Python tab for the "Authenticated Esplora" book section, and runnable example/tests: an authenticated watch-only scan, an online-watcher/offline-signer flow, and confidential-change handling.

### Validation
- **Rust:** offline unit tests for the `TokenProvider` conversion and builder wiring; `fmt` + `clippy` clean.
- **Authenticated, live:** ran a watch-only full scan of a real mainnet wallet through an authenticated enterprise endpoint — both the Esplora and Waterfalls code paths sync the same history (18 txs / 5 assets) and agree on balance; a negative path confirms invalid credentials are rejected. No private keys involved (watch-only).
- **Regtest:** the watch-only and confidential-change examples run end-to-end against `elementsd` + Liquid `electrs`.

### Reproducing the authenticated scan
Get OAuth2 API credentials from <https://dashboard.blockstream.info/> (and ensure the account has credits), then:

```bash
CLIENT_ID=<your-client-id> CLIENT_SECRET=<your-client-secret> \
PYTHONPATH=$PWD/target/release/bindings \
python3 lwk_bindings/tests/bindings/authenticated_wallet_scan.py
```

Defaults target the production enterprise endpoint; override with `ESPLORA_BASE_URL` / `ESPLORA_LOGIN_URL` (e.g. for UAT). Without `CLIENT_ID`/`CLIENT_SECRET` the test logs a skip and exits 0.

### API impact
No breaking changes. New additive binding API (`TokenProvider` + two optional builder fields); the only behavioral change is the Esplora client now erroring clearly on non-2xx responses.
