### PR TITLE
Reproducible build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,7 +160,7 @@ test_jade:
   script:
     - docker pull tulipan81/blind_pin_server:v0.0.7
     - docker pull xenoky/local-jade-emulator:1.0.27
-    - cargo test -p lwk_jade --features asyncr
+    - cargo test -p lwk_jade --features asyncr,test_emulator
 
 test_ledger:
   stage: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,13 @@ codegen-units = 1    # Reduce number of codegen units to increase optimizations.
 panic = "abort"      # Abort on panic
 strip = "debuginfo"  # Partially strip symbols from binary
 
+[profile.release-reproducible]
+inherits = "release"
+lto = "off"          # Disable both full LTO and Cargo's default thin-local LTO.
+codegen-units = 1    # Reduce backend scheduling/order variance.
+incremental = false  # Keep release artifacts independent from compiler cache state.
+strip = "symbols"    # Drop local symbol names that can be numbered nondeterministically.
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true         # Include debug symbols for profiling

--- a/lwk_bindings/Cargo.toml
+++ b/lwk_bindings/Cargo.toml
@@ -37,10 +37,14 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 name = "lwk"
 
 [features]
-default = ["lightning"]
+default = ["lightning", "uniffi_builtin_traits"]
 foreign_bindings = ["test_env"]
 lightning = ["lwk_boltz", "tokio", "log"]
 test_env = ["dep:lwk_test_util"]
+# Disable for deterministic release builds: uniffi 0.29.4 emits these built-in
+# trait exports in nondeterministic order when multiple traits are exported.
+# This is fixed on uniffi main and will likely be fixed in uniffi 0.31.2.
+uniffi_builtin_traits = []
 # Experimental: API behind this feature is unstable and may change without notice.
 simplicity = ["lwk_simplicity"]
 

--- a/lwk_bindings/Cargo.toml
+++ b/lwk_bindings/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/lwk_bindings"
 lwk_common = { version = "0.17.0" }
 lwk_signer = { version = "0.17.0" }
 lwk_wollet = { version = "0.17.0" }
-lwk_test_util = { version = "0.17.0" }
+lwk_test_util = { version = "0.17.0", optional = true }
 lwk_payment_instructions = { version = "0.17.0" }
 lwk_boltz = { version = "0.17.0", optional = true }
 lwk_simplicity = { version = "0.17.0", optional = true }
@@ -29,6 +29,7 @@ serde_json = "1"
 uniffi = { version = "=0.29.4", features = ["build"] }
 
 [dev-dependencies]
+lwk_test_util = { version = "0.17.0" }
 tempfile = "3.8.0"
 
 [lib]
@@ -37,8 +38,9 @@ name = "lwk"
 
 [features]
 default = ["lightning"]
-foreign_bindings = []
+foreign_bindings = ["test_env"]
 lightning = ["lwk_boltz", "tokio", "log"]
+test_env = ["dep:lwk_test_util"]
 # Experimental: API behind this feature is unstable and may change without notice.
 simplicity = ["lwk_simplicity"]
 

--- a/lwk_bindings/src/currency_code.rs
+++ b/lwk_bindings/src/currency_code.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 /// Currency code as defined by ISO 4217
 #[derive(uniffi::Object, PartialEq, Eq, Hash, Debug, Clone)]
-#[uniffi::export(Display, Hash, Eq)]
+#[cfg_attr(feature = "uniffi_builtin_traits", uniffi::export(Display, Hash, Eq))]
 pub struct CurrencyCode {
     pub(crate) inner: lwk_wollet::CurrencyCode,
 }

--- a/lwk_bindings/src/lib.rs
+++ b/lwk_bindings/src/lib.rs
@@ -28,6 +28,7 @@ mod pset;
 mod pset_details;
 mod signer;
 mod store;
+#[cfg(feature = "test_env")]
 mod test_env;
 mod tx_builder;
 pub mod types;
@@ -95,6 +96,7 @@ pub use pset::{Pset, PsetInput, PsetOutput};
 pub use pset::{PsetBuilder, PsetInputBuilder, PsetOutputBuilder};
 pub use pset_details::{Issuance, PsetDetails};
 pub use store::{ForeignStore, ForeignStoreLink};
+#[cfg(feature = "test_env")]
 pub use test_env::{LwkTestEnv, LwkTestStore};
 pub use tx_builder::TxBuilder;
 pub use update::Update;

--- a/lwk_bindings/src/network.rs
+++ b/lwk_bindings/src/network.rs
@@ -8,7 +8,7 @@ use crate::{types::AssetId, ElectrumClient, EsploraClient, LwkError, TxBuilder};
 
 /// The network of the elements blockchain.
 #[derive(uniffi::Object, PartialEq, Eq, Hash, Debug, Clone, Copy)]
-#[uniffi::export(Display, Hash, Eq)]
+#[cfg_attr(feature = "uniffi_builtin_traits", uniffi::export(Display, Hash, Eq))]
 pub struct Network {
     pub(crate) inner: lwk_common::Network,
 }

--- a/lwk_bindings/src/pos.rs
+++ b/lwk_bindings/src/pos.rs
@@ -4,7 +4,7 @@ use crate::{CurrencyCode, LwkError, WolletDescriptor};
 
 /// POS (Point of Sale) configuration for encoding/decoding
 #[derive(uniffi::Object, PartialEq, Eq, Hash, Debug, Clone)]
-#[uniffi::export(Display, Hash, Eq)]
+#[cfg_attr(feature = "uniffi_builtin_traits", uniffi::export(Display, Hash, Eq))]
 pub struct PosConfig {
     pub(crate) inner: lwk_wollet::PosConfig,
 }

--- a/lwk_jade/Cargo.toml
+++ b/lwk_jade/Cargo.toml
@@ -47,7 +47,7 @@ tokio = { version = "1.36.0", features = [
 web-time = "1.1.0"
 
 [features]
-default = ["sync", "test_emulator"]
+default = ["sync"]
 sync = []
 serial = ["serialport"]
 asyncr = ["tokio"]

--- a/lwk_jade/tests/emulator.rs
+++ b/lwk_jade/tests/emulator.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test_emulator")]
+
 use base64::Engine;
 use elements::{
     bitcoin::{self, bip32::Fingerprint, bip32::Xpub, sign_message::signed_msg_hash},


### PR DESCRIPTION
related to https://github.com/Blockstream/lwk/issues/165

I used this build command `direnv exec . cargo build --locked --profile release-reproducible -p lwk_bindings --no-default-features --features lightning --target-dir /tmp/`

And I got twice:

```
  size: 20,686,952 bytes
  hash : a385bdd3e92e16b1462f5e3498442858739151f397788a1fede15ae62c1470a3
```

Still a draft mostly because of the last commit, like this is of course a breaking change and removal of features, we should see if there is something from uniffi to solve the issue

