### PR TITLE
Add external utxo binding in WASM

### DIFF
--- a/lwk_wasm/src/pset.rs
+++ b/lwk_wasm/src/pset.rs
@@ -168,6 +168,19 @@ impl PsetInput {
             .map(|txout| txout.script_pubkey.clone().into())
     }
 
+    /// Prevout (witness) UTXO of the input, if present.
+    // Gated on `simplicity` because the wasm `TxOut` wrapper is only compiled with
+    // that feature; its motivating use is assembling the prevout set for
+    // `SimplicityProgram.finalizeTransaction`.
+    #[cfg(feature = "simplicity")]
+    #[wasm_bindgen(js_name = witnessUtxo)]
+    pub fn witness_utxo(&self) -> Option<TxOut> {
+        self.inner
+            .witness_utxo
+            .as_ref()
+            .map(|txout| txout.clone().into())
+    }
+
     /// Redeem script of the input
     #[wasm_bindgen(js_name = redeemScript)]
     pub fn redeem_script(&self) -> Option<Script> {

--- a/lwk_wasm/src/tx_builder.rs
+++ b/lwk_wasm/src/tx_builder.rs
@@ -4,8 +4,8 @@ use lwk_wollet::{elements, UnvalidatedRecipient, Validated};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    liquidex::ValidatedLiquidexProposal, Address, AssetId, Contract, Error, Network, OutPoint,
-    Pset, Transaction, Wollet,
+    liquidex::ValidatedLiquidexProposal, Address, AssetId, Contract, Error, ExternalUtxo, Network,
+    OutPoint, Pset, Transaction, Wollet,
 };
 
 /// A transaction builder
@@ -109,6 +109,12 @@ impl TxBuilder {
             .add_unvalidated_recipient(&unvalidated_recipient)
             .expect("recipient can't be invalid")
             .into()
+    }
+
+    /// Add an `OP_RETURN` output carrying arbitrary `data`, with zero value.
+    #[wasm_bindgen(js_name = addOpReturn)]
+    pub fn add_op_return(self, data: &[u8]) -> Result<TxBuilder, Error> {
+        Ok(self.inner.add_op_return(data)?.into())
     }
 
     /// Add explicit recipient
@@ -235,6 +241,16 @@ impl TxBuilder {
     pub fn set_inputs_order(self, outpoints: Vec<OutPoint>) -> TxBuilder {
         let outpoints: Vec<elements::OutPoint> = outpoints.into_iter().map(Into::into).collect();
         self.inner.set_inputs_order(outpoints).into()
+    }
+
+    /// Add external UTXOs (owned by another wallet, or a covenant) as inputs.
+    ///
+    /// Note: unblinded UTXOs with the same scriptpubkey as the wallet are still
+    /// considered external.
+    #[wasm_bindgen(js_name = addExternalUtxos)]
+    pub fn add_external_utxos(self, utxos: Vec<ExternalUtxo>) -> Result<TxBuilder, Error> {
+        let utxos: Vec<lwk_wollet::ExternalUtxo> = utxos.iter().map(Into::into).collect();
+        Ok(self.inner.add_external_utxos(utxos)?.into())
     }
 
     /// Return a string representation of the transaction builder (mostly for debugging)

--- a/lwk_wollet/src/tx_builder.rs
+++ b/lwk_wollet/src/tx_builder.rs
@@ -271,6 +271,17 @@ impl TxBuilder {
         self.add_unvalidated_recipient(&rec)
     }
 
+    /// Add an `OP_RETURN` output carrying arbitrary `data`, with zero value.
+    pub fn add_op_return(mut self, data: &[u8]) -> Result<Self, Error> {
+        self.recipients.push(Recipient {
+            satoshi: 0,
+            script_pubkey: Script::new_op_return(data),
+            blinding_pubkey: None,
+            asset: *self.network().policy_asset(),
+        });
+        Ok(self)
+    }
+
     /// Add explicit output
     pub fn add_explicit_recipient(
         mut self,
@@ -1677,6 +1688,14 @@ impl<'a> WolletTxBuilder<'a> {
         Ok(Self {
             wollet: self.wollet,
             inner: self.inner.add_burn(satoshi, asset_id)?,
+        })
+    }
+
+    /// Wrapper of [`TxBuilder::add_op_return()`]
+    pub fn add_op_return(self, data: &[u8]) -> Result<Self, Error> {
+        Ok(Self {
+            wollet: self.wollet,
+            inner: self.inner.add_op_return(data)?,
         })
     }
 

--- a/lwk_wollet/tests/e2e.rs
+++ b/lwk_wollet/tests/e2e.rs
@@ -4669,6 +4669,66 @@ fn test_issue_asset() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn op_return() {
+    // Build, sign and broadcast a transaction carrying an `OP_RETURN` output with a
+    // data payload, then check the explicit zero-value output landed on-chain.
+    let env = TestEnvBuilder::from_env().with_electrum().build();
+    let signer = generate_signer();
+    let view_key = generate_view_key();
+    let desc_str = format!("ct({view_key},elwpkh({}/*))", signer.xpub());
+    let client = test_client_electrum(&env.electrum_url());
+    let mut wallet = TestWollet::new(client, &desc_str);
+    let signers: [&AnySigner; 1] = [&AnySigner::Software(signer)];
+
+    wallet.fund_btc(&env);
+    let balance_before = wallet.balance_btc();
+
+    let data = b"lwk op_return";
+    let mut pset = wallet
+        .tx_builder()
+        .add_op_return(data)
+        .unwrap()
+        .finish()
+        .unwrap();
+    // Round-trip through the b64 string form (as PSETs are passed around in practice)
+    // to catch any (de)serialization issue introduced by the OP_RETURN output.
+    pset = pset_rt(&pset);
+
+    // The OP_RETURN output carries zero value, so only the fee is spent.
+    let details = wallet.wollet.get_details(&pset).unwrap();
+    let fee = details.balance.fees_in(&wallet.policy_asset()) as i64;
+    assert!(fee > 0);
+    assert_eq!(
+        *details
+            .balance
+            .balances
+            .get(&wallet.policy_asset())
+            .unwrap(),
+        -fee
+    );
+
+    for signer in &signers {
+        wallet.sign(signer, &mut pset);
+    }
+    let txid = wallet.send(&mut pset);
+
+    // The OP_RETURN output is not owned by the wallet, so it appears only in the raw
+    // transaction, as an explicit (unblinded) zero-value output.
+    let expected = elements::Script::new_op_return(data);
+    let tx = wallet.get_tx(&txid).tx;
+    let op_return = tx
+        .output
+        .iter()
+        .find(|o| o.script_pubkey == expected)
+        .expect("op_return output not found in broadcast tx");
+    assert!(op_return.script_pubkey.is_op_return());
+    assert_eq!(op_return.value.explicit(), Some(0));
+    assert!(op_return.nonce.is_null()); // unblinded
+
+    assert!(wallet.balance_btc() < balance_before);
+}
+
+#[test]
 fn test_zmq_endpoint() {
     let env = TestEnvBuilder::from_env().with_zmq().build();
     let zmq_url = env.zmq_endpoint();


### PR DESCRIPTION
Add support for OP_RETURN outputs with data payloads and external UTXO inputs to enable spending Simplicity covenant outputs.