### PR TITLE
wollet: fetch address histories concurrently

### DIFF
--- a/lwk_wollet/CHANGELOG.md
+++ b/lwk_wollet/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add the `electrum_oidc` feature: `TokenProvider::Blockstream` support for `ElectrumClient` (automatic OAuth2 token fetch, plus invalidate and retry once when the server denies a call with an authentication error). Not available on wasm.
 * `Wollet::assets_owned()` returns all assets ever owned instead of only unspent ones.
 * `Contract` no longer contains public fields. To build a `Contract` for issuance, use `Contract::builder`.
+* Esplora client: address history requests within a scan batch run concurrently, honoring `EsploraClientBuilder::concurrency` (default 1, so behavior is unchanged unless opted in).
 
 ## 0.18.0
 

--- a/lwk_wollet/src/clients/asyncr/esplora.rs
+++ b/lwk_wollet/src/clients/asyncr/esplora.rs
@@ -28,7 +28,7 @@ use futures::lock::Mutex;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::sync::Mutex;
 
-use futures::stream::{iter, StreamExt};
+use futures::stream::{iter, StreamExt, TryStreamExt};
 use reqwest::{Response, StatusCode};
 use serde::Deserialize;
 use std::sync::atomic::AtomicUsize;
@@ -217,11 +217,16 @@ impl EsploraClient {
         &self,
         addresses: &[Address],
     ) -> Result<Vec<Vec<History>>, Error> {
-        let mut result = vec![];
-        for address in addresses.iter() {
-            result.push(self.get_address_history(address).await?);
-        }
-        Ok(result)
+        // `buffered` (not `buffer_unordered`): callers map results back to
+        // derivation indices positionally (see `get_history`).
+        // Futures are created eagerly (inert until polled): an `&Address`-
+        // borrowing closure in the stream hits rust-lang/rust#89976 when
+        // async_trait consumers (e.g. lwk_boltz) need the future to be `Send`.
+        let futures: Vec<_> = addresses
+            .iter()
+            .map(|address| self.get_address_history(address))
+            .collect();
+        iter(futures).buffered(self.concurrency).try_collect().await
     }
 
     /// Fetch an address' unconfirmed transactions plus its full confirmed history.

--- a/lwk_wollet/tests/e2e.rs
+++ b/lwk_wollet/tests/e2e.rs
@@ -1077,7 +1077,11 @@ async fn test_esplora_address_history_paging() {
         first_page.len()
     );
 
-    let mut client = clients::asyncr::EsploraClient::new(network, &url);
+    // concurrency(4) also exercises the ordered concurrent address walk.
+    let mut client = clients::asyncr::EsploraClientBuilder::new(&url, network)
+        .concurrency(4)
+        .build()
+        .unwrap();
     for _ in 0..50 {
         if let Some(update) = client.full_scan(&wollet).await.unwrap() {
             wollet.apply_update(update).unwrap();


### PR DESCRIPTION
Follow-up to #169: the pagination half is superseded by f450cb31/94a57422, so per the closing invitation this brings back only the concurrency half, rebased on top of them.

`get_scripts_history_esplora` awaited one request per address sequentially; it now drives the batch through an ordered `buffered` stream honoring `EsploraClientBuilder::concurrency`. Default stays 1, so behavior is unchanged unless opted in.

One non-obvious bit: the per-address futures are instantiated eagerly (they stay inert until polled) — holding an `&Address`-borrowing closure in the stream trips rust-lang/rust#89976 when an `async_trait` consumer like lwk_boltz must prove the future `Send`.

The paging e2e (`test_esplora_address_history_paging`) now runs at `concurrency(4)`, so it also exercises the concurrent walk.
