### PR TITLE
feat(bindings): expose Elements regtest identity

### DIFF
--- a/lwk_bindings/CHANGELOG.md
+++ b/lwk_bindings/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added `Network::custom()` to bind an explicit Elements policy asset and genesis block hash.
+* Added `Network::regtest_with_genesis()` to bind an explicit Elements regtest policy asset and genesis block hash while retaining the standard regtest parent, address, epoch, pegin, and local-client parameters.
 * Added `DerivationPath`
 * Removed `get_path()`, replaced with `DerivationPath::from_account()`
 * Changed "simplicity" functions `derive_keypair()`, `simplicity_derive_xonly_pubkey()`, `create_p2pk_signature()` to accept `DerivatioPath` instead of `str`

--- a/lwk_bindings/CHANGELOG.md
+++ b/lwk_bindings/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added `Network::custom()` to bind an explicit Elements policy asset and genesis block hash.
 * Added `DerivationPath`
 * Removed `get_path()`, replaced with `DerivationPath::from_account()`
 * Changed "simplicity" functions `derive_keypair()`, `simplicity_derive_xonly_pubkey()`, `create_p2pk_signature()` to accept `DerivatioPath` instead of `str`

--- a/lwk_bindings/src/network.rs
+++ b/lwk_bindings/src/network.rs
@@ -1,8 +1,8 @@
-use std::{fmt::Display, sync::Arc};
+use std::{fmt::Display, str::FromStr, sync::Arc};
 
 use lwk_common::electrum_ssl::{LIQUID_SOCKET, LIQUID_TESTNET_SOCKET};
 
-use elements::hex::ToHex;
+use elements::{hex::ToHex, BlockHash};
 
 use crate::{types::AssetId, ElectrumClient, EsploraClient, LwkError, TxBuilder};
 
@@ -68,6 +68,24 @@ impl Network {
         )
     }
 
+    /// Return a custom Elements network with the given policy asset and genesis block hash.
+    ///
+    /// The genesis block hash uses the conventional display-order hexadecimal encoding returned
+    /// by Elements RPCs such as `getblockhash 0`.
+    #[uniffi::constructor]
+    pub fn custom(policy_asset: AssetId, genesis_hash: &str) -> Result<Arc<Network>, LwkError> {
+        let genesis_hash = BlockHash::from_str(genesis_hash).map_err(|e| LwkError::Generic {
+            msg: format!("invalid genesis block hash: {e}"),
+        })?;
+        let params = lwk_common::ElementsParamsBuilder::new()
+            .with_policy_asset(policy_asset.into())
+            .with_genesis_hash(genesis_hash)
+            .build()
+            .map_err(|e| LwkError::Generic { msg: e.to_string() })?;
+
+        Ok(Arc::new(lwk_common::Network::CustomElements(params).into()))
+    }
+
     /// Return the default regtest network with the default policy asset
     #[uniffi::constructor]
     pub fn regtest_default() -> Arc<Network> {
@@ -114,5 +132,44 @@ impl Network {
     /// Return a new `TxBuilder` for this network
     pub fn tx_builder(&self) -> Arc<TxBuilder> {
         Arc::new(TxBuilder::new(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ELEMENTS_REGTEST_GENESIS: &str =
+        "cd179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396f";
+    const ELEMENTS_REGTEST_POLICY_ASSET: &str =
+        "b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23";
+
+    fn elements_regtest_policy_asset() -> AssetId {
+        elements::AssetId::from_str(ELEMENTS_REGTEST_POLICY_ASSET)
+            .expect("valid asset id")
+            .into()
+    }
+
+    #[test]
+    fn custom_network_preserves_explicit_identity() {
+        let network = Network::custom(elements_regtest_policy_asset(), ELEMENTS_REGTEST_GENESIS)
+            .expect("valid custom network");
+
+        assert_eq!(
+            network.policy_asset().to_string(),
+            ELEMENTS_REGTEST_POLICY_ASSET
+        );
+        assert_eq!(network.genesis_block_hash(), ELEMENTS_REGTEST_GENESIS);
+        assert!(!network.is_mainnet());
+    }
+
+    #[test]
+    fn custom_network_rejects_invalid_genesis() {
+        assert!(Network::custom(elements_regtest_policy_asset(), "00").is_err());
+        assert!(Network::custom(
+            elements_regtest_policy_asset(),
+            "zz179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396f",
+        )
+        .is_err());
     }
 }

--- a/lwk_bindings/src/network.rs
+++ b/lwk_bindings/src/network.rs
@@ -68,12 +68,20 @@ impl Network {
         )
     }
 
-    /// Return a custom Elements network with the given policy asset and genesis block hash.
+    /// Return an Elements regtest network with the given policy asset and genesis block hash.
     ///
     /// The genesis block hash uses the conventional display-order hexadecimal encoding returned
     /// by Elements RPCs such as `getblockhash 0`.
+    ///
+    /// This retains LWK's standard Elements regtest parameters: Bitcoin regtest as the parent
+    /// chain, the `ert`/`el` address HRPs and `235`/`75`/`4` Base58 prefixes, dynamic epoch
+    /// length 10, total valid epochs 2, and localhost client defaults. It must not be used for an
+    /// arbitrary custom Elements chain that changes any of those parameters.
     #[uniffi::constructor]
-    pub fn custom(policy_asset: AssetId, genesis_hash: &str) -> Result<Arc<Network>, LwkError> {
+    pub fn regtest_with_genesis(
+        policy_asset: AssetId,
+        genesis_hash: &str,
+    ) -> Result<Arc<Network>, LwkError> {
         let genesis_hash = BlockHash::from_str(genesis_hash).map_err(|e| LwkError::Generic {
             msg: format!("invalid genesis block hash: {e}"),
         })?;
@@ -137,6 +145,11 @@ impl Network {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
     use super::*;
 
     const ELEMENTS_REGTEST_GENESIS: &str =
@@ -151,9 +164,12 @@ mod tests {
     }
 
     #[test]
-    fn custom_network_preserves_explicit_identity() {
-        let network = Network::custom(elements_regtest_policy_asset(), ELEMENTS_REGTEST_GENESIS)
-            .expect("valid custom network");
+    fn regtest_with_genesis_preserves_explicit_identity() {
+        let network = Network::regtest_with_genesis(
+            elements_regtest_policy_asset(),
+            ELEMENTS_REGTEST_GENESIS,
+        )
+        .expect("valid regtest network");
 
         assert_eq!(
             network.policy_asset().to_string(),
@@ -164,12 +180,79 @@ mod tests {
     }
 
     #[test]
-    fn custom_network_rejects_invalid_genesis() {
-        assert!(Network::custom(elements_regtest_policy_asset(), "00").is_err());
-        assert!(Network::custom(
+    fn regtest_with_genesis_canonicalizes_and_rejects_invalid_genesis() {
+        let uppercase = Network::regtest_with_genesis(
             elements_regtest_policy_asset(),
-            "zz179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396f",
+            &ELEMENTS_REGTEST_GENESIS.to_ascii_uppercase(),
         )
-        .is_err());
+        .expect("uppercase display hash is valid");
+        assert_eq!(uppercase.genesis_block_hash(), ELEMENTS_REGTEST_GENESIS);
+
+        for invalid in [
+            "",
+            "0",
+            "00",
+            "cd179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396",
+            "cd179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396f0",
+            "zd179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396f",
+            "cd179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396z",
+            " cd179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396f",
+            "cd179c84c35f51825f20a3b91a18d45f0c53b5ceb744a5b6ef8f0babe809396f ",
+        ] {
+            assert!(
+                Network::regtest_with_genesis(elements_regtest_policy_asset(), invalid).is_err(),
+                "accepted invalid genesis: {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn regtest_with_genesis_retains_standard_regtest_parameters() {
+        let network = Network::regtest_with_genesis(
+            elements_regtest_policy_asset(),
+            ELEMENTS_REGTEST_GENESIS,
+        )
+        .expect("valid regtest network");
+
+        assert_eq!(
+            network.inner.parent_genesis_hash(),
+            elements::bitcoin::constants::genesis_block(elements::bitcoin::Network::Regtest)
+                .header
+                .block_hash()
+        );
+        assert_eq!(
+            network.inner.address_params(),
+            &elements::AddressParams::ELEMENTS
+        );
+        assert_eq!(network.inner.dynamic_epoch_length(), 10);
+        assert_eq!(network.inner.total_valid_epochs(), 2);
+
+        let address = elements::Address::p2wsh(
+            &elements::Script::new(),
+            None,
+            network.inner.address_params(),
+        );
+        assert!(address.to_string().starts_with("ert1"));
+    }
+
+    #[test]
+    fn regtest_with_genesis_preserves_legacy_custom_network_hashing() {
+        let first = Network::regtest_with_genesis(
+            elements_regtest_policy_asset(),
+            ELEMENTS_REGTEST_GENESIS,
+        )
+        .expect("valid regtest network");
+        let second = Network::regtest_with_genesis(
+            elements_regtest_policy_asset(),
+            "00902a6b70c2ca83b5d9c815d96a0e2f4202179316970d14ea1847dae5b1ca21",
+        )
+        .expect("valid alternate regtest genesis");
+
+        assert_ne!(first, second);
+        let mut first_hasher = DefaultHasher::new();
+        first.hash(&mut first_hasher);
+        let mut second_hasher = DefaultHasher::new();
+        second.hash(&mut second_hasher);
+        assert_eq!(first_hasher.finish(), second_hasher.finish());
     }
 }


### PR DESCRIPTION
## Summary

- expose a fallible `Network::regtest_with_genesis` binding constructor;
- bind the caller's exact policy asset and display-order Elements genesis hash;
- document and test the retained standard Elements-regtest parent, address,
  epoch, pegin, and local-client parameters;
- preserve every existing network constructor and generated-binding ABI.

This closes a binding gap for callers that connect to an Elements regtest node
whose authenticated genesis and policy asset differ from LWK's compiled default.
It is intentionally not a general custom-Elements-network constructor.

## Validation

- 4 focused network identity/scope tests pass;
- complete `lwk_bindings --lib`: 43 pass, 0 fail, 1 ignored;
- stable clippy with `-D warnings`, formatting, and diff checks pass;
- generated C# binding builds and executes with .NET SDK 10.0.100;
- exact identity, uppercase canonicalization, malformed-genesis rejection, and
  legacy binding/new runtime compatibility pass.

The existing no-default-feature binding build remains blocked by the same 11
Lightning-gated UniFFI errors on the unchanged base and this branch.
